### PR TITLE
Spelling error

### DIFF
--- a/frontend/rakuyomi.koplugin/ChapterListing.lua
+++ b/frontend/rakuyomi.koplugin/ChapterListing.lua
@@ -504,7 +504,7 @@ function ChapterListing:openMarkDialog(manga, read, callback)
   dialog = InputDialog:new {
     title = _(read and "Mark read" or "Mark unread"),
     input_hint = _("1 - 10.5, 20 - 100"),
-    description = _("Mark chapters as read or unreadn\n\nLeaving blank will select all"),
+    description = _("Mark chapters as read or unread\n\nLeaving blank will select all"),
     buttons = {
       {
         {


### PR DESCRIPTION
### **User description**
This pull request makes a minor fix to the `openMarkDialog` function in `ChapterListing.lua`, correcting a typo in the dialog description.

* Fixed a typo in the `description` field of the mark dialog, changing "unreadn" to "unread" for improved clarity.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed typo in dialog description: "unreadn" to "unread"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ChapterListing.lua<br/>openMarkDialog function"] -- "Fix typo<br/>unreadn → unread" --> B["Corrected dialog<br/>description text"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChapterListing.lua</strong><dd><code>Fix typo in mark dialog description</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/rakuyomi.koplugin/ChapterListing.lua

<ul><li>Corrected typo in the <code>description</code> field of the mark dialog<br> <li> Changed "unreadn" to "unread" for proper spelling<br> <li> Improves clarity of user-facing dialog message</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/31/files#diff-7c84e8a7af17a02118ec0490c8a8a2ecac50710cac5590203eb0779c4dfdff10">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

