### PR TITLE
Improved UI strings

### DIFF
--- a/frontend/rakuyomi.koplugin/ChapterListing.lua
+++ b/frontend/rakuyomi.koplugin/ChapterListing.lua
@@ -414,7 +414,7 @@ end
 function ChapterListing:revokeChapter(chapter, hide_notify)
   Trapper:wrap(function()
     local revoke_chapter_response = LoadingDialog:showAndRun(
-      "Revoke chapter...",
+      "Removing chapter...",
       function()
         return Backend.revokeChapter(self.manga.source.id, self.manga.id, chapter.id)
       end
@@ -443,7 +443,7 @@ end
 function ChapterListing:markChapterAs(chapter, value)
   Trapper:wrap(function()
     local toggle_mark_response = LoadingDialog:showAndRun(
-      (value and "Marking" or "Un-marking") .. " chapter...",
+      (value and "Marking" or "Unmarking") .. " chapter...",
       function()
         return Backend.markChapterAsRead(self.manga.source.id, self.manga.id, chapter.id, value)
       end

--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -344,7 +344,7 @@ function LibraryView:onContextMenuChoice(item)
             })
           else
             UIManager:show(InfoMessage:new {
-              text = "Refreshed manga"
+              text = "Manga refreshed"
             })
           end
 
@@ -506,7 +506,7 @@ function LibraryView:openMenu()
     },
     {
       {
-        text = "\u{e000} Cleaner chapters",
+        text = "\u{e000} Clean up chapters",
         callback = function()
           UIManager:close(dialog)
 
@@ -598,7 +598,7 @@ function LibraryView:openMenu()
                         end
 
                         UIManager:show(InfoMessage:new {
-                          text = "Cloud database has been forcedly replaced with local one!"
+                          text = "Cloud database has been forcibly replaced with local one!"
                         })
 
                         UIManager:close(self)
@@ -876,7 +876,7 @@ function LibraryView:refreshAllChapters()
       ErrorDialog:show(msg)
     else
       UIManager:show(InfoMessage:new {
-        text = "All chapters manga updated!"
+        text = "All manga chapters updated!"
       })
     end
   end)
@@ -889,15 +889,15 @@ function LibraryView:openCleanerDialog()
   dialog = ConfirmBox:new {
     text = "Cleaner\n\n" ..
         "Normal: Find and delete invalid files including files from deleted sources\n\n" ..
-        "Chapter read done: Find and delete chapters that have been read\n\n" ..
-        "IMPORTANT: Meta files (bookmark, history) not keep!",
+        "Delete read chapters: Find and delete chapters that have been read\n\n" ..
+        "IMPORTANT: Meta files (bookmarks, history) will not be kept!",
     ok_text = "Normal",
     ok_callback = function()
       self:startCleaner(true)
     end,
     other_buttons = { {
       {
-        text = "Chapter read done",
+        text = "Delete read chapters",
         callback = function()
           self:startCleaner(false)
         end

--- a/frontend/rakuyomi.koplugin/MangaReader.lua
+++ b/frontend/rakuyomi.koplugin/MangaReader.lua
@@ -151,7 +151,7 @@ function MangaReader:overrideBtnFileManager(menu)
       if G_reader_settings:nilOrFalse(key) then
         local confirm_dialog
         confirm_dialog = ConfirmBox:new {
-          text = "どーも\nDo you want Rakuyomi to commandeer this button when you open it?\n\nThis setting only affects when you open it with Rakuyomi.",
+          text = "Do you want Rakuyomi to take over this button?\n\nThis setting only applies when opening files with Rakuyomi.",
           dismissable = false,
           ok_text = _("Yes"),
           cancel_text = _("No"),

--- a/frontend/rakuyomi.koplugin/NotificationView.lua
+++ b/frontend/rakuyomi.koplugin/NotificationView.lua
@@ -482,7 +482,7 @@ end
 function NotificationView:generateEmptyViewItemTable()
   return {
     {
-      text = "No notification",
+      text = "No notifications",
       dim = true,
       select_enabled = false,
     }


### PR DESCRIPTION
### **User description**
Fixed some errors in the UI strings


___

### **PR Type**
Enhancement


___

### **Description**
- Improved UI string clarity and grammar across multiple files

- Fixed capitalization and verb tense inconsistencies

- Enhanced user-facing messages for better readability

- Corrected spelling and punctuation in dialog boxes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["UI Strings in Multiple Files"] -->|"Fix grammar & spelling"| B["ChapterListing.lua"]
  A -->|"Improve message clarity"| C["LibraryView.lua"]
  A -->|"Simplify user prompts"| D["MangaReader.lua"]
  A -->|"Correct pluralization"| E["NotificationView.lua"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChapterListing.lua</strong><dd><code>Fix chapter action message strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/rakuyomi.koplugin/ChapterListing.lua

<ul><li>Changed "Revoke chapter..." to "Removing chapter..." for clarity<br> <li> Fixed "Un-marking" to "Unmarking" for correct spelling</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/44/files#diff-7c84e8a7af17a02118ec0490c8a8a2ecac50710cac5590203eb0779c4dfdff10">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LibraryView.lua</strong><dd><code>Improve menu and dialog message clarity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/rakuyomi.koplugin/LibraryView.lua

<ul><li>Changed "Refreshed manga" to "Manga refreshed" for better grammar<br> <li> Updated "Cleaner chapters" to "Clean up chapters" for clarity<br> <li> Fixed "forcedly" to "forcibly" for correct spelling<br> <li> Changed "All chapters manga updated!" to "All manga chapters updated!" <br>for proper word order<br> <li> Improved cleaner dialog text: "Chapter read done" to "Delete read <br>chapters"<br> <li> Fixed "not keep" to "will not be kept" and "Meta files" to "bookmarks, <br>history"</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/44/files#diff-1bd2ac64e42c1e4bf370012f81b08aab53d26fdff8958e0c2ae29aa8feaa6912">+7/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MangaReader.lua</strong><dd><code>Simplify file manager confirmation dialog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/rakuyomi.koplugin/MangaReader.lua

<ul><li>Removed Japanese greeting "どーも" from confirmation dialog<br> <li> Simplified "commandeer this button" to "take over this button"<br> <li> Changed "only affects when you open it" to "only applies when opening <br>files"</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/44/files#diff-5d515490e4b489ddeace3e865cf48899cfbf0121ec110f83dd9bbe2d4e30353b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>NotificationView.lua</strong><dd><code>Fix empty notification message pluralization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/rakuyomi.koplugin/NotificationView.lua

<ul><li>Changed "No notification" to "No notifications" for correct <br>pluralization</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/44/files#diff-ce35aa6f92cbbf2623f00a83c2288e981c0bf9efd3fb61fb08de04feda377c24">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

