### PR TITLE
feat: support for the "page" settings type (used by comix) + multilevel settings

### DIFF
--- a/backend/shared/src/source/model.rs
+++ b/backend/shared/src/source/model.rs
@@ -35,7 +35,7 @@ pub enum SettingDefinition {
         key: String,
         values: Vec<String>,
         titles: Option<Vec<String>>,
-        default: Vec<String>,
+        default: Option<Vec<String>>,
     },
     #[serde(rename = "login")]
     Login { title: String, key: String },
@@ -68,6 +68,13 @@ pub enum SettingDefinition {
     },
     #[serde(rename = "link")]
     Link { title: String, url: String },
+
+    #[serde(rename = "page")]
+    Page {
+        key: String,
+        title: String,
+        items: Vec<SettingDefinition>,
+    },
 }
 
 #[derive(Serialize, Debug, Clone, Default, PartialEq, FromPrimitive)]

--- a/backend/shared/src/source/source_settings.rs
+++ b/backend/shared/src/source/source_settings.rs
@@ -92,9 +92,10 @@ fn default_values_for_definition(
                     .unwrap_or_else(|| values.first().cloned().unwrap_or_default()),
             ),
         )]),
-        SettingDefinition::MultiSelect { key, default, .. } => {
-            HashMap::from([(key.clone(), SourceSettingValue::Vec(default.clone()))])
-        }
+        SettingDefinition::MultiSelect { key, default, .. } => HashMap::from([(
+            key.clone(),
+            SourceSettingValue::Vec(default.clone().unwrap_or_default()),
+        )]),
         SettingDefinition::EditableList { key, default, .. } => {
             HashMap::from([(key.clone(), SourceSettingValue::Vec(default.clone()))])
         }

--- a/frontend/rakuyomi.koplugin/widgets/SettingItemValue.lua
+++ b/frontend/rakuyomi.koplugin/widgets/SettingItemValue.lua
@@ -68,8 +68,12 @@ end
 --- @private
 --- @return any
 function SettingItemValue:getCurrentValue()
-  if (self.value_definition.type == 'enum' or self.value_definition.type == 'multi-enum') and self.value == nil then
-    return self.value_definition.options[1].value
+  if self.value == nil then
+    if self.value_definition.type == 'enum' then
+      return self.value_definition.options[1].value
+    elseif self.value_definition.type == 'multi-enum' then
+      return {}
+    end
   end
   return self.value
 end
@@ -152,12 +156,15 @@ function SettingItemValue:createValueWidget()
       truncate_left = true,
     }
   elseif self.value_definition.type == "button" then
+    local confirmText = (self.value_definition.confirm_title or "") ..
+        "\n\n" .. (self.value_definition.confirm_message or "")
+
     return ButtonWidget:new {
       text = self.value_definition.title,
       callback = function()
         local confirm_dialog
         confirm_dialog = ConfirmBox:new {
-          text = self.value_definition.confirm_title .. "\n\n" .. self.value_definition.confirm_message,
+          text = confirmText,
           ok_text = _("Ok"),
           cancel_text = _("Cancel"),
           ok_callback = function()


### PR DESCRIPTION
### **User description**
Allow the use of the comix source. 

May need manual tests to make sure the new multi-level settings page doesn't blow up.


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for "page" settings type for nested multi-level settings

- Make MultiSelect default value optional in backend model

- Refactor frontend settings rendering to recursively handle nested pages

- Improve default value handling for multi-enum and button widgets


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SettingDefinition enum"] -->|"Add Page variant"| B["Page with nested items"]
  C["MultiSelect default"] -->|"Make optional"| D["Optional Vec String"]
  E["Frontend SourceSettings"] -->|"Recursive rendering"| F["Support nested pages"]
  G["SettingItemValue"] -->|"Improve defaults"| H["Better null handling"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>model.rs</strong><dd><code>Add Page variant and optional MultiSelect defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/shared/src/source/model.rs

<ul><li>Add new <code>Page</code> variant to <code>SettingDefinition</code> enum with key, title, and <br>nested items<br> <li> Change <code>MultiSelect</code> default field from <code>Vec<String></code> to <code>Option<Vec<String>></code></ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/73/files#diff-ea39dbe3dacbaee1b6e6b8bf7ebc8c11a6b7b325ada1447959f67b2a024956ce">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>source_settings.rs</strong><dd><code>Handle optional MultiSelect defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/shared/src/source/source_settings.rs

<ul><li>Update <code>MultiSelect</code> default value handling to use <code>unwrap_or_default()</code> <br>for optional defaults<br> <li> Maintain backward compatibility with existing settings</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/73/files#diff-fb90a143e182c5c1dd14ef86644007a31035d38e8deace70d28765ed9d32da16">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SourceSettings.lua</strong><dd><code>Refactor to support recursive nested page rendering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/rakuyomi.koplugin/SourceSettings.lua

<ul><li>Refactor settings rendering into recursive <code>addSettings()</code> function to <br>support nested pages<br> <li> Treat "page" type identically to "group" type for hierarchical <br>rendering<br> <li> Simplify loop logic by removing separate group/child handling<br> <li> Fix indentation inconsistency in button type handler</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/73/files#diff-d7ccdc7d453fb0509a533657377b8a4477507cc9626febcb87fd2e310cca662d">+53/-63</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SettingItemValue.lua</strong><dd><code>Add page type support and improve null handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/rakuyomi.koplugin/widgets/SettingItemValue.lua

<ul><li>Add mapping for "page" type in <code>mapSettingDefinitionToValueDefinition()</code> <br>function<br> <li> Improve <code>getCurrentValue()</code> to return empty table for multi-enum when <br>value is nil<br> <li> Fix button widget to safely handle optional confirm_title and <br>confirm_message fields</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/73/files#diff-dafa8ea2984881de40411378868f86ae4d19a0880991a08508623f1b1599ad89">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

