### PR TITLE
docs: fix url for settings schema

### DIFF
--- a/docs/src/user-guide/installation/installing-to-your-device.md
+++ b/docs/src/user-guide/installation/installing-to-your-device.md
@@ -14,7 +14,7 @@ Any source that can run on [Aidoku](https://github.com/Aidoku) can also run on [
 
 ```json,downloadable:settings.json
 {
-  "$schema": "https://github.com/tachibana-shin/rakuyomi/releases/download/main/settings.schema.json",
+  "$schema": "https://github.com/tachibana-shin/rakuyomi/releases/latest/download/settings.schema.json",
   "source_lists": [
     "https://raw.githubusercontent.com/tachibana-shin/aidoku-community-sources/gh-pages/index.min.json",
     


### PR DESCRIPTION
### **User description**
Quick one here, the schema URL for latest settings schema was wrong, you can test both below

### OLD
[https://github.com/tachibana-shin/rakuyomi/releases/download/main/settings.schema.json](https://github.com/tachibana-shin/rakuyomi/releases/download/main/settings.schema.json)

### NEW
_(should download the file)_
[https://github.com/tachibana-shin/rakuyomi/releases/latest/download/settings.schema.json](https://github.com/tachibana-shin/rakuyomi/releases/latest/download/settings.schema.json)


___

### **PR Type**
Documentation


___

### **Description**
- Fix settings schema URL to use latest release

- Changed from main branch to latest release endpoint

- Ensures users download current schema version


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["Old URL: /releases/download/main/"]
  new["New URL: /releases/latest/download/"]
  old -- "Updated to" --> new
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>installing-to-your-device.md</strong><dd><code>Update settings schema URL to latest release</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/src/user-guide/installation/installing-to-your-device.md

<ul><li>Updated <code>$schema</code> URL in settings.json example<br> <li> Changed from <code>/releases/download/main/</code> to <code>/releases/latest/download/</code><br> <li> Ensures users always get the latest settings schema version</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/74/files#diff-569b76685100d6be5544997a76d1c395229770f596e37b1e11b5df164faedcac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

