### PR TITLE
Fix-89

### DIFF
--- a/frontend/rakuyomi.koplugin/gettext+.lua
+++ b/frontend/rakuyomi.koplugin/gettext+.lua
@@ -315,9 +315,7 @@ function GetText_mt.__index.loadMO(file)
       logger.warn(string.format("bad translation file: %s [singular / plurals mismatch]", file))
     else
       if n == 1 and #os == 0 then
-        if parse_headers(ts) == false then
-          return false
-        end
+        parse_headers(ts)
       else
         addTranslation(ctx, os, ts)
       end


### PR DESCRIPTION
### **User description**
closes #89


___

### **PR Type**
Bug fix


___

### **Description**
- Remove debug print statement from language loading

- Add missing Plural-Forms header fallback with default value

- Propagate parsing errors from headers during MO file loading

- Improve error handling in parse_headers function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MO File Loading"] --> B["Parse Headers"]
  B --> C{"Plural-Forms Header Present?"}
  C -->|Yes| D["Use Header Value"]
  C -->|No| E["Use Default Value"]
  D --> F["Return Success/Failure"]
  E --> F
  F --> G["Propagate Errors"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>gettext+.lua</strong><dd><code>Fix MO file parsing and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/rakuyomi.koplugin/gettext+.lua

<ul><li>Removed debug <code>print(mo)</code> statement from <code>changeLang</code> function<br> <li> Added nil check for missing Plural-Forms header with default fallback <br>value<br> <li> Modified <code>loadMO</code> function to propagate parsing errors from <br><code>parse_headers</code><br> <li> Improved error handling by returning false when header parsing fails</ul>


</details>


  </td>
  <td><a href="https://github.com/tachibana-shin/rakuyomi/pull/91/files#diff-e9d5ab5d24a0f76963ada0fd9948a156533e4af525c5698ffbe1e2e8401f8b5e">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

