### PR TITLE
chore: add macOS dev environment scripts

### DIFF
--- a/tools/dev-macos.sh
+++ b/tools/dev-macos.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Launches KOReader with the rakuyomi plugin.
+#
+# - The server runs via `cargo run` (recompiles on restart when source changes).
+# - uds_http_request and cbz_metadata_reader are pre-built and copied into the
+#   plugin directory on each launch. Rebuild them manually with:
+#   cargo build -p uds_http_request -p cbz_metadata_reader
+#   if you change their source.
+#
+# Run setup-macos.sh first if you haven't already.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+KOREADER_BIN="$REPO_ROOT/build/macos/KOReader.app/Contents/MacOS/koreader"
+# setup-macos.sh installs the plugin to the user data dir when it exists (to avoid
+# double-loading), so resolve the effective plugin dir the same way.
+if [[ -d "$HOME/Library/Application Support/koreader" ]]; then
+    PLUGIN_DIR="$HOME/Library/Application Support/koreader/plugins/rakuyomi.koplugin"
+else
+    PLUGIN_DIR="$REPO_ROOT/build/macos/KOReader.app/Contents/koreader/plugins/rakuyomi.koplugin"
+fi
+
+if [[ ! -x "$KOREADER_BIN" ]]; then
+    echo "KOReader not found. Run './tools/setup-macos.sh' first."
+    exit 1
+fi
+
+# Source cargo env in case this is a fresh shell and PATH isn't updated yet.
+[[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
+
+# Reinstall Lua plugin on every launch so frontend changes are picked up immediately.
+bash "$REPO_ROOT/tools/setup-macos.sh" 2>/dev/null | grep -v "^===" || true
+
+# Build request-path binaries and copy them into the plugin directory.
+# KOReader looks for these at plugin_dir/uds_http_request and plugin_dir/cbz_metadata_reader.
+# We avoid env var overrides here since macOS app bundles don't reliably inherit
+# shell environment variables.
+echo "Building uds_http_request and cbz_metadata_reader..."
+cargo build --manifest-path "$REPO_ROOT/backend/Cargo.toml" \
+    -p uds_http_request -p cbz_metadata_reader -q
+cp "$REPO_ROOT/backend/target/debug/uds_http_request" "$PLUGIN_DIR/uds_http_request"
+cp "$REPO_ROOT/backend/target/debug/cbz_metadata_reader" "$PLUGIN_DIR/cbz_metadata_reader"
+
+# The server uses `cargo run` via execl (not io.popen), so env var inheritance
+# works correctly for it. This gives hot recompilation on server source changes.
+export RAKUYOMI_SERVER_COMMAND_OVERRIDE="$HOME/.cargo/bin/cargo run --manifest-path $REPO_ROOT/backend/Cargo.toml -p server --"
+export RAKUYOMI_SERVER_WORKING_DIRECTORY="$REPO_ROOT"
+export RAKUYOMI_SERVER_STARTUP_TIMEOUT="${RAKUYOMI_SERVER_STARTUP_TIMEOUT:-600}"
+
+# uds_http_request and cbz_metadata_reader are called via io.popen in Lua.
+# The plugin directory on macOS is under ~/Library/Application Support/... which
+# has spaces and breaks shell invocation. Point directly to the pre-built binaries
+# in the repo (no spaces in that path).
+export RAKUYOMI_UDS_HTTP_REQUEST_COMMAND_OVERRIDE="$REPO_ROOT/backend/target/debug/uds_http_request"
+export RAKUYOMI_CBZ_METADATA_READER_COMMAND_OVERRIDE="$REPO_ROOT/backend/target/debug/cbz_metadata_reader"
+
+exec "$KOREADER_BIN" "$HOME"

--- a/tools/dev-macos.sh
+++ b/tools/dev-macos.sh
@@ -30,7 +30,7 @@ fi
 [[ -f "$HOME/.cargo/env" ]] && source "$HOME/.cargo/env"
 
 # Reinstall Lua plugin on every launch so frontend changes are picked up immediately.
-bash "$REPO_ROOT/tools/setup-macos.sh" 2>/dev/null | grep -v "^===" || true
+rsync -a --exclude='*_spec.lua' "$REPO_ROOT/frontend/rakuyomi.koplugin/" "$PLUGIN_DIR/"
 
 # Build request-path binaries and copy them into the plugin directory.
 # KOReader looks for these at plugin_dir/uds_http_request and plugin_dir/cbz_metadata_reader.

--- a/tools/setup-macos.sh
+++ b/tools/setup-macos.sh
@@ -93,15 +93,7 @@ copy_plugin_to() {
     local dest="$1"
     rm -rf "$dest"
     mkdir -p "$dest"
-    find "$REPO_ROOT/frontend/rakuyomi.koplugin" \
-        -not -name "*_spec.lua" \
-        -not -type d \
-        | while read -r f; do
-            local rel="${f#$REPO_ROOT/frontend/rakuyomi.koplugin/}"
-            local target="$dest/$rel"
-            mkdir -p "$(dirname "$target")"
-            cp "$f" "$target"
-        done
+    rsync -a --exclude='*_spec.lua' "$REPO_ROOT/frontend/rakuyomi.koplugin/" "$dest/"
 }
 
 install_plugin() {

--- a/tools/setup-macos.sh
+++ b/tools/setup-macos.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# Sets up a local macOS development environment without requiring Nix/devenv.
+# Safe to re-run — existing extracted KOReader is reused, plugin is always refreshed.
+
+set -e
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$REPO_ROOT/build/macos"
+KOREADER_APP="$BUILD_DIR/KOReader.app"
+PLUGIN_DEST="$KOREADER_APP/Contents/koreader/plugins/rakuyomi.koplugin"
+KOREADER_ZIP="$REPO_ROOT/packages/koreader-macos-arm64.zip"
+
+ensure_cargo_in_shell() {
+    local shell_rc="$HOME/.zshrc"
+    local cargo_env_line='. "$HOME/.cargo/env"'
+    if ! grep -qF "$cargo_env_line" "$shell_rc" 2>/dev/null; then
+        echo "" >> "$shell_rc"
+        echo "# Added by rakuyomi setup-macos.sh" >> "$shell_rc"
+        echo "$cargo_env_line" >> "$shell_rc"
+        echo "Added Cargo to PATH in $shell_rc"
+    fi
+}
+
+install_rust() {
+    echo "Rust not found. Installing via rustup..."
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
+    source "$HOME/.cargo/env"
+    ensure_cargo_in_shell
+    echo "Rust installed."
+}
+
+install_toolchain() {
+    local version
+    version="$(grep '^channel' "$REPO_ROOT/rust-toolchain.toml" | sed 's/.*= *"//' | sed 's/".*//')"
+    echo "Installing Rust toolchain $version (required by rust-toolchain.toml)..."
+    rustup toolchain install "$version"
+}
+
+install_p7zip() {
+    if ! command -v brew &>/dev/null; then
+        echo "Homebrew is required to install p7zip but was not found."
+        echo "Install Homebrew from https://brew.sh, then re-run this script."
+        exit 1
+    fi
+    echo "p7zip not found. Installing via Homebrew..."
+    brew install p7zip
+}
+
+check_deps() {
+    if ! command -v cargo &>/dev/null; then
+        # cargo may exist but not be on PATH yet (e.g. fresh rustup install)
+        if [[ -f "$HOME/.cargo/env" ]]; then
+            source "$HOME/.cargo/env"
+        fi
+        if ! command -v cargo &>/dev/null; then
+            install_rust
+        fi
+    fi
+
+    install_toolchain
+
+    if ! command -v 7za &>/dev/null && ! command -v 7zz &>/dev/null; then
+        install_p7zip
+    fi
+}
+
+extract_koreader() {
+    if [[ -d "$KOREADER_APP" ]]; then
+        echo "KOReader already extracted, skipping."
+        return
+    fi
+
+    echo "Extracting KOReader..."
+    mkdir -p "$BUILD_DIR"
+
+    local tmp
+    tmp="$(mktemp -d)"
+    trap "rm -rf '$tmp'" EXIT
+
+    unzip -q "$KOREADER_ZIP" -d "$tmp"
+
+    local sevenz_bin
+    sevenz_bin="$(command -v 7zz 2>/dev/null || command -v 7za)"
+
+    local archive
+    archive="$(find "$tmp" -name "*.7z" | head -1)"
+    "$sevenz_bin" x "$archive" -o"$BUILD_DIR" -y >/dev/null
+
+    echo "KOReader extracted to $KOREADER_APP"
+}
+
+copy_plugin_to() {
+    local dest="$1"
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    find "$REPO_ROOT/frontend/rakuyomi.koplugin" \
+        -not -name "*_spec.lua" \
+        -not -type d \
+        | while read -r f; do
+            local rel="${f#$REPO_ROOT/frontend/rakuyomi.koplugin/}"
+            local target="$dest/$rel"
+            mkdir -p "$(dirname "$target")"
+            cp "$f" "$target"
+        done
+}
+
+install_plugin() {
+    echo "Installing plugin..."
+
+    local user_plugin_dest="$HOME/Library/Application Support/koreader/plugins/rakuyomi.koplugin"
+
+    if [[ -d "$HOME/Library/Application Support/koreader" ]]; then
+        # KOReader already has a user data dir — install only there.
+        # KOReader scans both the app bundle and the user dir; installing to both
+        # causes the plugin to be loaded twice (backend was already initialized).
+        copy_plugin_to "$user_plugin_dest"
+        # Remove from app bundle to prevent double-loading.
+        rm -rf "$PLUGIN_DEST"
+        echo "Plugin installed to $user_plugin_dest"
+    else
+        # Fresh KOReader — no user data dir yet. Install to the app bundle so
+        # KOReader finds it on first launch and populates its user dir.
+        copy_plugin_to "$PLUGIN_DEST"
+        echo "Plugin installed to $PLUGIN_DEST"
+    fi
+}
+
+echo "=== rakuyomi macOS dev setup ==="
+check_deps
+extract_koreader
+install_plugin
+echo ""
+echo "Done! Run './tools/dev-macos.sh' to launch KOReader with the plugin."


### PR DESCRIPTION
Adds two scripts for macOS contributors who prefer not to use Nix/devenv:

- `tools/setup-macos.sh` — one-time setup: installs Rust via rustup, extracts the bundled KOReader binary, and installs the plugin
- `tools/dev-macos.sh` — launches KOReader with the plugin on every run, picking up Lua changes automatically and running the backend via `cargo run`

The existing Nix/devenv workflow is untouched.

## Demo
https://www.loom.com/share/5a45c32b87d84f84aeb8e4fc4a5dc8ce
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tachibana-shin/rakuyomi/pull/150" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
