### PR TITLE
feat: add gallery view to search results

### DIFF
--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -258,6 +258,7 @@ async fn get_mangas(
         database,
         source_manager,
         cancel_token_store,
+        chapter_storage,
         ..
     }): StateExtractor<State>,
     Query(GetMangasQuery {
@@ -268,6 +269,7 @@ async fn get_mangas(
 ) -> Result<Json<(Vec<Manga>, Vec<usecases::search_mangas::SearchError>)>, AppError> {
     let source_manager = { &*source_manager.lock().await };
     let database = { database.lock().await };
+    let chapter_storage = chapter_storage.lock().await;
     let token = create_token(cancel_token_store, cancel_id).await;
 
     let exclude = exclude.map(|v| {
@@ -276,11 +278,25 @@ async fn get_mangas(
             .collect::<Vec<_>>()
     });
 
-    let (mangas, errors) = cancel_after(&token.0, Duration::from_secs(59), |token| {
-        usecases::search_mangas(source_manager, &database, token, q, &exclude, 30)
+    let (mut mangas, errors) = cancel_after(&token.0, Duration::from_secs(59), |token| {
+        usecases::search_mangas(source_manager, &database, &chapter_storage, token, q, &exclude, 30)
     })
     .await
     .map_err(AppError::from_search_mangas_error)?;
+
+    for manga in mangas.iter_mut() {
+        if manga.information.cover_url.is_some() {
+            if let Some(path) = chapter_storage.poster_exists(&manga.information.id) {
+                manga.information.cover_url = match url::Url::from_file_path(&path) {
+                    Ok(url) => Some(url),
+                    Err(_) => match url::Url::from_file_path(path.canonicalize().unwrap()) {
+                        Ok(url) => Some(url),
+                        Err(_) => None,
+                    },
+                };
+            }
+        }
+    }
 
     let results = mangas.into_iter().map(Manga::from).collect();
 

--- a/backend/shared/src/chapter_storage.rs
+++ b/backend/shared/src/chapter_storage.rs
@@ -414,3 +414,89 @@ impl ChapterStorage {
         self.downloads_folder_path.join(output_filename)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use size::Size;
+    use tempfile::tempdir;
+
+    fn make_storage() -> ChapterStorage {
+        let dir = tempdir().unwrap();
+        ChapterStorage::new(dir.into_path(), Size::from_mebibytes(100.0)).unwrap()
+    }
+
+    fn make_rgb_jpeg(width: u32, height: u32) -> Vec<u8> {
+        let pixels: Vec<u8> = vec![128u8; (width * height * 3) as usize];
+        let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
+        comp.set_size(width as usize, height as usize);
+        comp.set_fastest_defaults();
+        let mut comp = comp.start_compress(Vec::new()).unwrap();
+        comp.write_scanlines(&pixels).unwrap();
+        comp.finish().unwrap()
+    }
+
+    fn output_dimensions(jpeg: &[u8]) -> (u32, u32) {
+        let cursor = std::io::Cursor::new(jpeg);
+        let img = image::ImageReader::new(cursor)
+            .with_guessed_format()
+            .unwrap()
+            .decode()
+            .unwrap();
+        (img.width(), img.height())
+    }
+
+    #[test]
+    fn small_image_is_stored_unchanged() {
+        let storage = make_storage();
+        let input = make_rgb_jpeg(200, 300);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert_eq!((w, h), (200, 300));
+    }
+
+    #[test]
+    fn wide_image_is_capped_at_max_width() {
+        let storage = make_storage();
+        // 1200x400 — wider than MAX_WIDTH (400), height within limit
+        let input = make_rgb_jpeg(1200, 400);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert!(w <= 400, "width {w} exceeds MAX_WIDTH");
+        // Aspect ratio preserved: 1200/400 = 3.0, so h should be ~133
+        assert_eq!(w, 400);
+        assert_eq!(h, 133);
+    }
+
+    #[test]
+    fn tall_image_is_capped_at_max_height() {
+        let storage = make_storage();
+        // 200x1200 — taller than MAX_HEIGHT (600), width within limit
+        let input = make_rgb_jpeg(200, 1200);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert!(h <= 600, "height {h} exceeds MAX_HEIGHT");
+        assert_eq!(h, 600);
+        assert_eq!(w, 100);
+    }
+
+    #[test]
+    fn large_portrait_cover_fits_within_bounds() {
+        let storage = make_storage();
+        // Typical high-res manga cover
+        let input = make_rgb_jpeg(1400, 2100);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert!(w <= 400, "width {w} exceeds MAX_WIDTH");
+        assert!(h <= 600, "height {h} exceeds MAX_HEIGHT");
+    }
+
+    #[test]
+    fn exact_max_dimensions_are_not_resized() {
+        let storage = make_storage();
+        let input = make_rgb_jpeg(400, 600);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert_eq!((w, h), (400, 600));
+    }
+}

--- a/backend/shared/src/chapter_storage.rs
+++ b/backend/shared/src/chapter_storage.rs
@@ -120,6 +120,12 @@ impl ChapterStorage {
     }
 
     fn convert_image_data_to_jpeg(&self, data: &[u8]) -> Result<Vec<u8>> {
+        // Maximum poster dimensions. Covers are displayed as small thumbnails so
+        // full-resolution originals are wasteful and can exceed KOReader's LRU
+        // image cache when loaded as raw bitmaps.
+        const MAX_WIDTH: u32 = 400;
+        const MAX_HEIGHT: u32 = 600;
+
         let (width, height, rgb_pixels) = {
             if let Some(data) = decode_image_fast(data) {
                 let image = data?;
@@ -155,6 +161,24 @@ impl ChapterStorage {
 
                 (width, height, rgb_img.to_vec())
             }
+        };
+
+        // Downscale to fit within MAX_WIDTH x MAX_HEIGHT, preserving aspect ratio.
+        let (width, height, rgb_pixels) = if width > MAX_WIDTH || height > MAX_HEIGHT {
+            let scale = (MAX_WIDTH as f32 / width as f32).min(MAX_HEIGHT as f32 / height as f32);
+            let new_width = ((width as f32 * scale).round() as u32).max(1);
+            let new_height = ((height as f32 * scale).round() as u32).max(1);
+            let img = image::RgbImage::from_raw(width, height, rgb_pixels)
+                .context("failed to build image buffer for resize")?;
+            let resized = image::imageops::resize(
+                &img,
+                new_width,
+                new_height,
+                image::imageops::FilterType::Triangle,
+            );
+            (new_width, new_height, resized.into_raw())
+        } else {
+            (width, height, rgb_pixels)
         };
 
         let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);

--- a/backend/shared/src/usecases/search_mangas.rs
+++ b/backend/shared/src/usecases/search_mangas.rs
@@ -1,4 +1,5 @@
 use crate::{
+    chapter_storage::ChapterStorage,
     database::Database,
     model::{Manga, MangaInformation, MangaState, SourceInformation},
     source_collection::SourceCollection,
@@ -21,6 +22,7 @@ pub struct SearchError {
 pub async fn search_mangas(
     source_collection: &impl SourceCollection,
     db: &Database,
+    chapter_storage: &ChapterStorage,
     cancellation_token: CancellationToken,
     query: String,
     exclude: &Option<Vec<String>>,
@@ -44,6 +46,7 @@ pub async fn search_mangas(
             .map(|source| {
                 let cancellation_token = cancellation_token.clone();
                 let query = query.to_string();
+                let chapter_storage = chapter_storage.clone();
 
                 async move {
                     if exclude
@@ -108,6 +111,18 @@ pub async fn search_mangas(
                     let _ = db
                         .upsert_cached_manga_information(&manga_informations)
                         .await;
+
+                    // Download posters for each result so cover/grid view can render them
+                    for info in &manga_informations {
+                        if let Some(cover_url) = &info.cover_url {
+                            let url = cover_url.clone();
+                            let _ = chapter_storage
+                                .cached_poster(&token, &info.id, || {
+                                    source.get_image_request(url.clone(), None)
+                                })
+                                .await;
+                        }
+                    }
 
                     // Fetch unread chapters count for each manga
                     let manga_ids: Vec<_> =

--- a/docs/superpowers/plans/2026-04-16-search-gallery-view.md
+++ b/docs/superpowers/plans/2026-04-16-search-gallery-view.md
@@ -4,9 +4,9 @@
 
 **Goal:** Add cover and grid view modes to the manga search results screen, toggleable via a title bar icon and a plugin settings entry, persisted in `G_reader_settings`.
 
-**Architecture:** `MangaSearchResults` is switched from `Menu:extend` to `MenuCustom:extend` to gain grid-column layout support. A `search_view_mode` field (read from `G_reader_settings` on init) drives which `MenuItem` class is used in `updateItems()`. A left title bar icon cycles through the three modes on tap. A new `is_local` entry in `Settings.lua` exposes the same key in the settings menu.
+**Architecture:** `MangaSearchResults` is switched from `Menu:extend` to `MenuCustom:extend` to gain grid-column layout support. A `search_view_mode` field (read from `G_reader_settings` on init) drives which `MenuItem` class is used in `updateItems()`. A left title bar icon cycles through the three modes on tap and emits a `search_view_mode_changed` IPC event for testability. A new `is_local` entry in `Settings.lua` exposes the same key in the settings menu.
 
-**Tech Stack:** LuaJIT, KOReader widget API (`Menu`, `MenuCustom`, `MenuItemCover`, `MenuItemGrid`), `G_reader_settings` for local persistence.
+**Tech Stack:** LuaJIT, KOReader widget API (`Menu`, `MenuCustom`, `MenuItemCover`, `MenuItemGrid`), `G_reader_settings` for local persistence. E2E tests use pytest + `KOReaderDriver` (pyautogui + LLM-based UI queries).
 
 ---
 
@@ -14,8 +14,9 @@
 
 | File | Change |
 |------|--------|
-| `frontend/rakuyomi.koplugin/MangaSearchResults.lua` | Extend `MenuCustom`, add view mode field, title bar toggle, update `updateItems` and `generateItemTableFromSearchResults` |
+| `frontend/rakuyomi.koplugin/MangaSearchResults.lua` | Extend `MenuCustom`, add view mode field, title bar toggle + event emit, update `updateItems` and `generateItemTableFromSearchResults` |
 | `frontend/rakuyomi.koplugin/Settings.lua` | Add `rakuyomi_search_view_mode` entry under a new Search divider |
+| `e2e-tests/tests/test_search_view_modes.py` | New e2e test: toggle cycles modes, UI reflects each mode, mode persists across searches |
 
 ---
 
@@ -134,7 +135,7 @@ end
 
 - [ ] **Step 3: Add cycleViewMode()**
 
-Add this method after `init()`:
+Add this method after `init()`. It cycles the mode, persists to `G_reader_settings`, re-renders, and emits an IPC event so the e2e test can wait on it:
 
 ```lua
 function MangaSearchResults:cycleViewMode()
@@ -149,6 +150,7 @@ function MangaSearchResults:cycleViewMode()
   self.search_view_mode = next_mode
   G_reader_settings:saveSetting("rakuyomi_search_view_mode", next_mode)
   self:updateItems()
+  Testing:emitEvent("search_view_mode_changed", { mode = next_mode })
 end
 ```
 
@@ -221,29 +223,119 @@ function MangaSearchResults:generateItemTableFromSearchResults(results)
 end
 ```
 
-- [ ] **Step 7: Manual test — list view (base)**
+- [ ] **Step 7: Manual smoke test**
 
-Launch with `./tools/dev-macos.sh`. Search for any manga. Confirm results display as a list (current behavior unchanged). The title bar should show the `column.two` icon on the left.
+Launch with `./tools/dev-macos.sh`. Search for any manga. Confirm:
+- Default view is a text list with the `column.two` icon in the title bar
+- Tapping the icon once switches to cover art view
+- Tapping again switches to grid view
+- Tapping again returns to list view
 
-- [ ] **Step 8: Manual test — cover view**
-
-Tap the `column.two` icon once. Confirm the results switch to cover art view with source name displayed below each title.
-
-- [ ] **Step 9: Manual test — grid view**
-
-Tap the icon again. Confirm the results switch to grid view using the same column count as the library grid setting.
-
-- [ ] **Step 10: Manual test — persistence**
-
-While in grid mode, close the search results and open a new search. Confirm the view mode is still grid. Restart KOReader and confirm it persists across sessions.
-
-- [ ] **Step 11: Manual test — settings menu**
-
-Open plugin settings. Change "Search view mode" to a different value. Open search results and confirm the new mode is applied.
-
-- [ ] **Step 12: Commit**
+- [ ] **Step 8: Commit**
 
 ```bash
 git add frontend/rakuyomi.koplugin/MangaSearchResults.lua
 git commit -m "feat: add gallery view to search results"
+```
+
+---
+
+### Task 3: Add e2e test for search view modes
+
+**Files:**
+- Create: `e2e-tests/tests/test_search_view_modes.py`
+
+- [ ] **Step 1: Create the test file**
+
+Create `e2e-tests/tests/test_search_view_modes.py` with the following content:
+
+```python
+import time
+from typing import Literal
+
+from pydantic import BaseModel
+
+from . import queries
+from .queries.locate_button import LocateButtonResponse
+from .koreader_driver import KOReaderDriver
+
+
+class SearchViewModeResponse(BaseModel):
+    mode: Literal['base', 'cover', 'grid']
+
+
+async def get_search_view_mode(driver: KOReaderDriver) -> str:
+    response = await driver.query(
+        "What is the current view mode of the search results? "
+        "Reply with 'base' if items are shown as a plain text list with no images, "
+        "'cover' if items show cover art on the left side next to text, "
+        "or 'grid' if items are arranged in multiple columns each showing cover art.",
+        SearchViewModeResponse,
+    )
+    return response.mode
+
+
+async def open_search(driver: KOReaderDriver, query: str) -> None:
+    menu_button = await queries.locate_button(driver, "menu")
+    driver.click_element(menu_button)
+
+    search_button = await queries.locate_button(driver, "Search")
+    driver.click_element(search_button)
+    time.sleep(1)
+
+    driver.type(query)
+    search_button = await queries.locate_button(driver, "Search")
+    driver.click_element(search_button)
+
+    await driver.wait_for_event('manga_search_results_shown')
+
+
+async def test_search_view_modes(koreader_driver: KOReaderDriver):
+    await koreader_driver.install_source('multi.batoto')
+    await koreader_driver.open_library_view()
+
+    # Open an initial search
+    await open_search(koreader_driver, 'houseki no kuni')
+
+    # Default should be base (list) view
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'base', f"Expected default view mode 'base', got '{mode}'"
+
+    # Tap toggle → cover
+    toggle = await koreader_driver.query(
+        "Locate the view mode toggle icon button in the top left corner of the title bar",
+        LocateButtonResponse,
+    )
+    koreader_driver.click_element(toggle)
+    await koreader_driver.wait_for_event('search_view_mode_changed')
+
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'cover', f"Expected view mode 'cover', got '{mode}'"
+
+    # Tap toggle → grid
+    toggle = await koreader_driver.query(
+        "Locate the view mode toggle icon button in the top left corner of the title bar",
+        LocateButtonResponse,
+    )
+    koreader_driver.click_element(toggle)
+    await koreader_driver.wait_for_event('search_view_mode_changed')
+
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'grid', f"Expected view mode 'grid', got '{mode}'"
+
+    # Close search and reopen — mode should persist
+    back_button = await queries.locate_button(koreader_driver, "Back")
+    koreader_driver.click_element(back_button)
+
+    await open_search(koreader_driver, 'houseki no kuni')
+
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'grid', f"Expected persisted view mode 'grid', got '{mode}'"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add e2e-tests/tests/test_search_view_modes.py
+git commit -m "test: add e2e test for search view mode cycling and persistence"
 ```

--- a/docs/superpowers/plans/2026-04-16-search-gallery-view.md
+++ b/docs/superpowers/plans/2026-04-16-search-gallery-view.md
@@ -1,0 +1,249 @@
+# Search Gallery View Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add cover and grid view modes to the manga search results screen, toggleable via a title bar icon and a plugin settings entry, persisted in `G_reader_settings`.
+
+**Architecture:** `MangaSearchResults` is switched from `Menu:extend` to `MenuCustom:extend` to gain grid-column layout support. A `search_view_mode` field (read from `G_reader_settings` on init) drives which `MenuItem` class is used in `updateItems()`. A left title bar icon cycles through the three modes on tap. A new `is_local` entry in `Settings.lua` exposes the same key in the settings menu.
+
+**Tech Stack:** LuaJIT, KOReader widget API (`Menu`, `MenuCustom`, `MenuItemCover`, `MenuItemGrid`), `G_reader_settings` for local persistence.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `frontend/rakuyomi.koplugin/MangaSearchResults.lua` | Extend `MenuCustom`, add view mode field, title bar toggle, update `updateItems` and `generateItemTableFromSearchResults` |
+| `frontend/rakuyomi.koplugin/Settings.lua` | Add `rakuyomi_search_view_mode` entry under a new Search divider |
+
+---
+
+### Task 1: Add search_view_mode to Settings
+
+**Files:**
+- Modify: `frontend/rakuyomi.koplugin/Settings.lua:36-104`
+
+- [ ] **Step 1: Add the Search divider and search_view_mode entry**
+
+In `Settings.lua`, insert the following two entries immediately after the closing brace of the `rakuyomi_grid_rows` block (after line 104) and before the `Reader` divider:
+
+```lua
+  {
+    nil,
+    { type = 'divider', title = _("Search") }
+  },
+  {
+    'rakuyomi_search_view_mode',
+    {
+      type = 'enum',
+      title = _("Search view mode"),
+      options = {
+        { label = _("Base"),  value = "base" },
+        { label = _("Cover"), value = "cover" },
+        { label = _("Grid"),  value = "grid" },
+      },
+      is_local = true,
+      default = "base",
+    }
+  },
+```
+
+The `is_local = true` flag causes `Settings:init()` to read/write this key via `G_reader_settings` automatically — no additional handler code needed.
+
+- [ ] **Step 2: Verify the settings screen renders without error**
+
+Launch KOReader with `./tools/dev-macos.sh`, open the plugin settings, and confirm the new "Search" section appears with a "Search view mode" entry defaulting to "Base". Changing it should not crash.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/rakuyomi.koplugin/Settings.lua
+git commit -m "feat: add search view mode setting"
+```
+
+---
+
+### Task 2: Implement view mode in MangaSearchResults
+
+**Files:**
+- Modify: `frontend/rakuyomi.koplugin/MangaSearchResults.lua`
+
+- [ ] **Step 1: Add the new requires and switch to MenuCustom**
+
+Replace the existing require block and class declaration at the top of `MangaSearchResults.lua`. The file currently starts with:
+
+```lua
+local Menu = require("widgets/Menu")
+```
+
+and the class is declared as:
+
+```lua
+local MangaSearchResults = Menu:extend {
+```
+
+Update to:
+
+```lua
+local Menu = require("widgets/Menu")
+local MenuCustom = require("patch/MenuCustom")
+local MenuItemCover = require("patch/MenuItemCover")
+local MenuItemGrid = require("patch/MenuItemGrid")
+```
+
+and change the class declaration to:
+
+```lua
+local MangaSearchResults = MenuCustom:extend {
+  name = "manga_search_results",
+  is_enable_shortcut = false,
+  is_popout = false,
+  title = _("Search results..."),
+  with_context_menu = true,
+
+  results = nil,
+  on_return_callback = nil,
+}
+```
+
+- [ ] **Step 2: Update init() to read the view mode and wire the title bar icon**
+
+Replace the existing `MangaSearchResults:init()` with:
+
+```lua
+function MangaSearchResults:init()
+  self.results = self.results or {}
+  self.search_view_mode = G_reader_settings:readSetting("rakuyomi_search_view_mode", "base")
+
+  self.title_bar_left_icon = "column.two"
+  self.onLeftButtonTap = function()
+    self:cycleViewMode()
+  end
+
+  self.width = Screen:getWidth()
+  self.height = Screen:getHeight()
+  local page = self.page
+  Menu.init(self)
+  self.page = page
+
+  self.paths = { 0 }
+  self.on_return_callback = nil
+end
+```
+
+- [ ] **Step 3: Add cycleViewMode()**
+
+Add this method after `init()`:
+
+```lua
+function MangaSearchResults:cycleViewMode()
+  local modes = { "base", "cover", "grid" }
+  local next_mode = "base"
+  for i, mode in ipairs(modes) do
+    if mode == self.search_view_mode then
+      next_mode = modes[(i % #modes) + 1]
+      break
+    end
+  end
+  self.search_view_mode = next_mode
+  G_reader_settings:saveSetting("rakuyomi_search_view_mode", next_mode)
+  self:updateItems()
+end
+```
+
+- [ ] **Step 4: Add _recalculateDimen()**
+
+Add this method after `cycleViewMode()`:
+
+```lua
+function MangaSearchResults:_recalculateDimen(flag)
+  if self.search_view_mode ~= "base" then
+    MenuCustom._recalculateDimen(self, flag)
+  else
+    Menu._recalculateDimen(self, flag)
+  end
+end
+```
+
+- [ ] **Step 5: Replace updateItems()**
+
+Replace the existing `MangaSearchResults:updateItems()` with:
+
+```lua
+function MangaSearchResults:updateItems()
+  self.item_table = self:generateItemTableFromSearchResults(self.results)
+
+  local mode = self.search_view_mode
+  if mode == "grid" then
+    self.grid_columns = G_reader_settings:readSetting("rakuyomi_grid_columns") or 3
+    MenuCustom.updateItems(self, MenuItemGrid)
+  elseif mode == "cover" then
+    self.grid_columns = nil
+    MenuCustom.updateItems(self, MenuItemCover)
+  else
+    self.grid_columns = nil
+    Menu.updateItems(self)
+  end
+end
+```
+
+- [ ] **Step 6: Update generateItemTableFromSearchResults() to include manga_cover**
+
+Replace the existing `MangaSearchResults:generateItemTableFromSearchResults()` with:
+
+```lua
+function MangaSearchResults:generateItemTableFromSearchResults(results)
+  local item_table = {}
+  local is_cover = self.search_view_mode == "cover"
+
+  for _, manga in ipairs(results) do
+    local mandatory = (manga.last_read and calcLastReadText(manga.last_read) .. " " or "")
+
+    if manga.unread_chapters_count ~= nil and manga.unread_chapters_count > 0 then
+      mandatory = mandatory .. Icons.FA_BELL .. manga.unread_chapters_count
+    end
+
+    if manga.in_library then
+      mandatory = mandatory .. Icons.COD_LIBRARY
+    end
+
+    table.insert(item_table, {
+      manga = manga,
+      text = manga.title,
+      post_text = is_cover and mandatory or manga.source.name,
+      manga_cover = self.search_view_mode ~= "base" and manga.manga_cover or nil,
+      mandatory = not is_cover and mandatory or nil,
+    })
+  end
+
+  return item_table
+end
+```
+
+- [ ] **Step 7: Manual test — list view (base)**
+
+Launch with `./tools/dev-macos.sh`. Search for any manga. Confirm results display as a list (current behavior unchanged). The title bar should show the `column.two` icon on the left.
+
+- [ ] **Step 8: Manual test — cover view**
+
+Tap the `column.two` icon once. Confirm the results switch to cover art view with source name displayed below each title.
+
+- [ ] **Step 9: Manual test — grid view**
+
+Tap the icon again. Confirm the results switch to grid view using the same column count as the library grid setting.
+
+- [ ] **Step 10: Manual test — persistence**
+
+While in grid mode, close the search results and open a new search. Confirm the view mode is still grid. Restart KOReader and confirm it persists across sessions.
+
+- [ ] **Step 11: Manual test — settings menu**
+
+Open plugin settings. Change "Search view mode" to a different value. Open search results and confirm the new mode is applied.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add frontend/rakuyomi.koplugin/MangaSearchResults.lua
+git commit -m "feat: add gallery view to search results"
+```

--- a/docs/superpowers/specs/2026-04-16-search-gallery-view-design.md
+++ b/docs/superpowers/specs/2026-04-16-search-gallery-view-design.md
@@ -1,0 +1,45 @@
+# Search Gallery View
+
+## Summary
+
+Add gallery (cover and grid) view modes to the manga search results screen, mirroring the existing library view modes. The preference is stored separately from the library setting and persists across sessions.
+
+## Goals
+
+- Users can view search results in list, cover, or grid mode
+- The active mode is toggled via an icon in the search results title bar
+- The same setting is also accessible from the plugin settings menu
+- Defaults to list (`base`) so existing users see no change
+
+## Non-Goals
+
+- Migrating `library_view_mode` from backend settings to `G_reader_settings` (future cleanup)
+- Changing the grid column/row counts (reuses the existing `rakuyomi_grid_columns` / `rakuyomi_grid_rows` settings)
+
+## Storage
+
+`G_reader_settings` key: `rakuyomi_search_view_mode`  
+Values: `"base"` | `"cover"` | `"grid"`  
+Default: `"base"`
+
+No backend/Rust changes required.
+
+## Components
+
+### MangaSearchResults.lua
+
+- Extend `MenuCustom` instead of `Menu` to gain grid column layout support
+- Add `search_view_mode` field, read from `G_reader_settings` on init
+- Add a title bar left icon that cycles `base → cover → grid → base` on tap:
+  - Saves the new mode to `G_reader_settings` immediately
+  - Re-renders the list with the new mode applied
+- In `updateItems()`:
+  - `"cover"` → use `MenuItemCover`, `grid_columns = nil`
+  - `"grid"` → use `MenuItemGrid`, `grid_columns` read from `rakuyomi_grid_columns`
+  - `"base"` → use default `MenuItem`, `grid_columns = nil`
+
+### Settings.lua
+
+- Add a `search_view_mode` entry with labels Base / Cover / Grid
+- Reads and writes directly to `G_reader_settings` (not the backend settings API)
+- Positioned alongside the existing `library_view_mode` entry

--- a/e2e-tests/tests/test_search_view_modes.py
+++ b/e2e-tests/tests/test_search_view_modes.py
@@ -1,0 +1,81 @@
+import time
+from typing import Literal
+
+from pydantic import BaseModel
+
+from . import queries
+from .queries.locate_button import LocateButtonResponse
+from .koreader_driver import KOReaderDriver
+
+
+class SearchViewModeResponse(BaseModel):
+    mode: Literal['base', 'cover', 'grid']
+
+
+async def get_search_view_mode(driver: KOReaderDriver) -> str:
+    response = await driver.query(
+        "What is the current view mode of the search results? "
+        "Reply with 'base' if items are shown as a plain text list with no images, "
+        "'cover' if items show cover art on the left side next to text, "
+        "or 'grid' if items are arranged in multiple columns each showing cover art.",
+        SearchViewModeResponse,
+    )
+    return response.mode
+
+
+async def open_search(driver: KOReaderDriver, query: str) -> None:
+    menu_button = await queries.locate_button(driver, "menu")
+    driver.click_element(menu_button)
+
+    search_button = await queries.locate_button(driver, "Search")
+    driver.click_element(search_button)
+    time.sleep(1)
+
+    driver.type(query)
+    search_button = await queries.locate_button(driver, "Search")
+    driver.click_element(search_button)
+
+    await driver.wait_for_event('manga_search_results_shown')
+
+
+async def test_search_view_modes(koreader_driver: KOReaderDriver):
+    await koreader_driver.install_source('multi.batoto')
+    await koreader_driver.open_library_view()
+
+    # Open an initial search
+    await open_search(koreader_driver, 'houseki no kuni')
+
+    # Default should be base (list) view
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'base', f"Expected default view mode 'base', got '{mode}'"
+
+    # Tap toggle → cover
+    toggle = await koreader_driver.query(
+        "Locate the view mode toggle icon button in the top left corner of the title bar",
+        LocateButtonResponse,
+    )
+    koreader_driver.click_element(toggle)
+    await koreader_driver.wait_for_event('search_view_mode_changed')
+
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'cover', f"Expected view mode 'cover', got '{mode}'"
+
+    # Tap toggle → grid
+    toggle = await koreader_driver.query(
+        "Locate the view mode toggle icon button in the top left corner of the title bar",
+        LocateButtonResponse,
+    )
+    koreader_driver.click_element(toggle)
+    await koreader_driver.wait_for_event('search_view_mode_changed')
+
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'grid', f"Expected view mode 'grid', got '{mode}'"
+
+    # Close search and reopen — mode should persist
+    back_button = await queries.locate_button(koreader_driver, "Back")
+    koreader_driver.click_element(back_button)
+
+    await open_search(koreader_driver, 'houseki no kuni')
+
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'grid', f"Expected persisted view mode 'grid', got '{mode}'"

--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -8,6 +8,9 @@ local addToPlaylist = require("handlers/addToPlaylist")
 local Backend = require("Backend")
 local ErrorDialog = require("ErrorDialog")
 local Menu = require("widgets/Menu")
+local MenuCustom = require("patch/MenuCustom")
+local MenuItemCover = require("patch/MenuItemCover")
+local MenuItemGrid = require("patch/MenuItemGrid")
 local LoadingDialog = require("LoadingDialog")
 local ChapterListing = require("ChapterListing")
 local Testing = require("testing")
@@ -19,33 +22,64 @@ local Trapper = require("ui/trapper")
 --- @class MangaSearchResults: { [any]: any }
 --- @field results Manga[]
 --- @field on_return_callback fun(): nil
-local MangaSearchResults = Menu:extend {
+local MangaSearchResults = MenuCustom:extend {
   name = "manga_search_results",
   is_enable_shortcut = false,
   is_popout = false,
   title = _("Search results..."),
   with_context_menu = true,
 
-  -- list of mangas
   results = nil,
-  -- callback to be called when pressing the back button
   on_return_callback = nil,
 }
 
 function MangaSearchResults:init()
-  self.results = self.results or {}
+  -- Stash results before Menu.init so its internal updateItems() call sees an
+  -- empty list. Without this, covers are loaded once inside Menu.init and again
+  -- in our explicit updateItems() below, exhausting the LRU image cache.
+  local results = self.results or {}
+  self.results = {}
+  self.search_view_mode = G_reader_settings:readSetting("rakuyomi_search_view_mode", "base")
+
+  self.title_bar_left_icon = "column.two"
+  self.onLeftButtonTap = function()
+    self:cycleViewMode()
+  end
+
   self.width = Screen:getWidth()
   self.height = Screen:getHeight()
   local page = self.page
   Menu.init(self)
+  MenuCustom.init(self)
   self.page = page
 
-  -- see `ChapterListing` for an explanation on this
-  -- FIXME we could refactor this into a single class
   self.paths = { 0 }
   self.on_return_callback = nil
+  self.results = results
+  self:updateItems()
+end
 
-  -- self:updateItems()
+function MangaSearchResults:cycleViewMode()
+  local modes = { "base", "cover", "grid" }
+  local next_mode = "base"
+  for i, mode in ipairs(modes) do
+    if mode == self.search_view_mode then
+      next_mode = modes[(i % #modes) + 1]
+      break
+    end
+  end
+  self.search_view_mode = next_mode
+  G_reader_settings:saveSetting("rakuyomi_search_view_mode", next_mode)
+  self:updateItems()
+  Testing:emitEvent("search_view_mode_changed", { mode = next_mode })
+end
+
+function MangaSearchResults:_recalculateDimen(flag)
+  if self.search_view_mode ~= "base" then
+    MenuCustom._recalculateDimen(self, flag)
+  else
+    Menu._recalculateDimen(self, flag)
+  end
 end
 
 function MangaSearchResults:onClose()
@@ -60,7 +94,17 @@ end
 function MangaSearchResults:updateItems()
   self.item_table = self:generateItemTableFromSearchResults(self.results)
 
-  Menu.updateItems(self)
+  local mode = self.search_view_mode
+  if mode == "grid" then
+    self.grid_columns = G_reader_settings:readSetting("rakuyomi_grid_columns") or 3
+    MenuCustom.updateItems(self, MenuItemGrid)
+  elseif mode == "cover" then
+    self.grid_columns = nil
+    MenuCustom.updateItems(self, MenuItemCover)
+  else
+    self.grid_columns = nil
+    Menu.updateItems(self)
+  end
 end
 
 --- Generates the item table for displaying the search results.
@@ -69,22 +113,25 @@ end
 --- @return table
 function MangaSearchResults:generateItemTableFromSearchResults(results)
   local item_table = {}
+  local is_cover = self.search_view_mode == "cover"
+
   for _, manga in ipairs(results) do
     local mandatory = (manga.last_read and calcLastReadText(manga.last_read) .. " " or "")
 
     if manga.unread_chapters_count ~= nil and manga.unread_chapters_count > 0 then
-      mandatory = (mandatory or "") .. Icons.FA_BELL .. manga.unread_chapters_count
+      mandatory = mandatory .. Icons.FA_BELL .. manga.unread_chapters_count
     end
 
     if manga.in_library then
-      mandatory = (mandatory or "") .. Icons.COD_LIBRARY
+      mandatory = mandatory .. Icons.COD_LIBRARY
     end
 
     table.insert(item_table, {
       manga = manga,
       text = manga.title,
-      post_text = manga.source.name,
-      mandatory = mandatory,
+      post_text = is_cover and mandatory or manga.source.name,
+      manga_cover = self.search_view_mode ~= "base" and manga.manga_cover or nil,
+      mandatory = not is_cover and mandatory or nil,
     })
   end
 
@@ -228,7 +275,7 @@ function MangaSearchResults:onContextMenuChoice(item)
             local added = manga.in_library
             manga.in_library = not added
 
-            if manga.in_library and Backend.getSettings().body.library_view_mode ~= 'base' then
+            if manga.in_library and self.search_view_mode ~= 'base' then
               local cancel_id = Backend.createCancelId()
               local response, cancelled = LoadingDialog:showAndRun(
                 _("Refreshing details..."),
@@ -284,11 +331,11 @@ function MangaSearchResults:onContextMenuChoice(item)
             local onReturnCallback = function()
               local ui = MangaSearchResults:new {
                 results = self.results,
-                on_return_callback = self.onReturnCallback,
+                on_return_callback = self.on_return_callback,
                 covers_fullscreen = true, -- hint for UIManager:_repaint()
                 page = self.page
               }
-              ui.on_return_callback = self.onReturnCallback
+              ui.on_return_callback = self.on_return_callback
               UIManager:show(ui)
             end
             MangaInfoWidget:fetchAndShow(manga, onReturnCallback)

--- a/frontend/rakuyomi.koplugin/Settings.lua
+++ b/frontend/rakuyomi.koplugin/Settings.lua
@@ -104,6 +104,24 @@ Settings.setting_value_definitions = {
   },
   {
     nil,
+    { type = 'divider', title = _("Search") }
+  },
+  {
+    'rakuyomi_search_view_mode',
+    {
+      type = 'enum',
+      title = _("Search view mode"),
+      options = {
+        { label = _("Base"),  value = "base" },
+        { label = _("Cover"), value = "cover" },
+        { label = _("Grid"),  value = "grid" },
+      },
+      is_local = true,
+      default = "base",
+    }
+  },
+  {
+    nil,
     { type = 'divider', title = _("Reader") }
   },
   {

--- a/frontend/rakuyomi.koplugin/patch/MenuItemCover.lua
+++ b/frontend/rakuyomi.koplugin/patch/MenuItemCover.lua
@@ -429,8 +429,11 @@ function MenuItemCover:genCover(wleft_width, wleft_height)
 
   local wleft
   if self.entry.manga_cover and starts_with(self.entry.manga_cover, "file://") then
+    local cover_path = self.entry.manga_cover:gsub("^file://", ""):gsub("%%(%x%x)", function(hex)
+      return string.char(tonumber(hex, 16))
+    end)
     local wimage = ImageWidget:new {
-      file = self.entry.manga_cover:gsub("^file://", ""),
+      file = cover_path,
       -- scale_factor = 0.5
     }
     wimage:_loadfile()
@@ -438,7 +441,7 @@ function MenuItemCover:genCover(wleft_width, wleft_height)
     local _, _, scale_factor = getCachedCoverSize(image_size.w, image_size.h, wleft_width, wleft_height)
 
     wimage = ImageWidget:new {
-      file = self.entry.manga_cover:gsub("^file://", ""),
+      file = cover_path,
       scale_factor = scale_factor
     }
 


### PR DESCRIPTION
## Summary

- Adds cover and grid view modes to the manga search results screen, mirroring the existing library view
- A toggle icon in the title bar cycles between list → cover → grid → list; the same setting is also accessible from the plugin settings menu
- View mode persists across sessions via `G_reader_settings` (`rakuyomi_search_view_mode`, default: `base`)
- Posters are downloaded during search so cover/grid renders without requiring the manga to be opened first
- Poster dimensions are capped at 400×600 on download to prevent KOReader's LRU image cache from overflowing on large source images


https://github.com/user-attachments/assets/2217f7ec-b7e1-4ffa-a24b-d2603d9b051f