### PR TITLE
feat: add gallery view to search results

### DIFF
--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -7,6 +7,7 @@ use futures::Future;
 use log::warn;
 use serde::{Deserialize, Serialize};
 use shared::model::{ChapterId, MangaId, NotificationInformation};
+use shared::settings::SearchViewMode;
 use shared::usecases;
 use tokio_util::sync::CancellationToken;
 
@@ -254,6 +255,7 @@ async fn get_mangas(
         source_manager,
         cancel_token_store,
         chapter_storage,
+        settings,
         ..
     }): StateExtractor<State>,
     Query(GetMangasQuery {
@@ -264,7 +266,8 @@ async fn get_mangas(
 ) -> Result<Json<(Vec<Manga>, Vec<usecases::search_mangas::SearchError>)>, AppError> {
     let source_manager = { &*source_manager.lock().await };
     let database = { database.lock().await };
-    let chapter_storage = chapter_storage.lock().await.clone();
+    let chapter_storage = chapter_storage.lock().await;
+    let with_covers = settings.lock().await.search_view_mode != SearchViewMode::Base;
     let token = create_token(cancel_token_store, cancel_id).await;
 
     let exclude = exclude.map(|v| {
@@ -274,16 +277,18 @@ async fn get_mangas(
     });
 
     let (mut mangas, errors) = cancel_after(&token.0, Duration::from_secs(59), |token| {
-        usecases::search_mangas(source_manager, &database, &chapter_storage, token, q, &exclude, 30)
+        usecases::search_mangas(source_manager, &database, &chapter_storage, token, q, &exclude, 30, with_covers)
     })
     .await
     .map_err(AppError::from_search_mangas_error)?;
 
-    for manga in mangas.iter_mut() {
-        if manga.information.cover_url.is_some() {
-            manga.information.cover_url = chapter_storage
-                .poster_exists(&manga.information.id)
-                .and_then(|path| path_to_file_url(&path));
+    if with_covers {
+        for manga in mangas.iter_mut() {
+            if manga.information.cover_url.is_some() {
+                manga.information.cover_url = chapter_storage
+                    .poster_exists(&manga.information.id)
+                    .and_then(|path| path_to_file_url(&path));
+            }
         }
     }
 

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -16,11 +16,16 @@ use crate::state::State;
 use crate::AppError;
 
 fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
-    url::Url::from_file_path(path).ok().or_else(|| {
-        path.canonicalize()
-            .ok()
-            .and_then(|p| url::Url::from_file_path(p).ok())
-    })
+    match url::Url::from_file_path(&path) {
+        Ok(url) => Some(url),
+        Err(_) => match url::Url::from_file_path(path.canonicalize().unwrap()) {
+            Ok(url) => Some(url),
+            Err(_) => {
+                println!("Error converting path to URL");
+                None
+            }
+        },
+    }
 }
 
 pub fn routes() -> Router<State> {
@@ -254,6 +259,7 @@ async fn get_mangas(
         source_manager,
         cancel_token_store,
         chapter_storage,
+        settings,
         ..
     }): StateExtractor<State>,
     Query(GetMangasQuery {
@@ -265,6 +271,7 @@ async fn get_mangas(
     let source_manager = { &*source_manager.lock().await };
     let database = { database.lock().await };
     let chapter_storage = chapter_storage.lock().await;
+    let settings = settings.lock().await;
     let token = create_token(cancel_token_store, cancel_id).await;
 
     let exclude = exclude.map(|v| {
@@ -274,16 +281,27 @@ async fn get_mangas(
     });
 
     let (mut mangas, errors) = cancel_after(&token.0, Duration::from_secs(59), |token| {
-        usecases::search_mangas(source_manager, &database, &chapter_storage, token, q, &exclude, 30)
+        usecases::search_mangas(
+            source_manager,
+            &database,
+            &chapter_storage,
+            &settings,
+            token,
+            q,
+            &exclude,
+            30,
+        )
     })
     .await
     .map_err(AppError::from_search_mangas_error)?;
 
-    for manga in mangas.iter_mut() {
-        if manga.information.cover_url.is_some() {
-            manga.information.cover_url = chapter_storage
-                .poster_exists(&manga.information.id)
-                .and_then(|path| path_to_file_url(&path));
+    if settings.search_view_mode != shared::settings::SearchViewMode::Base {
+        for manga in mangas.iter_mut() {
+            if manga.information.cover_url.is_some() {
+                manga.information.cover_url = chapter_storage
+                    .poster_exists(&manga.information.id)
+                    .and_then(|path| path_to_file_url(&path));
+            }
         }
     }
 

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -258,6 +258,7 @@ async fn get_mangas(
         database,
         source_manager,
         cancel_token_store,
+        chapter_storage,
         ..
     }): StateExtractor<State>,
     Query(GetMangasQuery {
@@ -268,6 +269,7 @@ async fn get_mangas(
 ) -> Result<Json<(Vec<Manga>, Vec<usecases::search_mangas::SearchError>)>, AppError> {
     let source_manager = { &*source_manager.lock().await };
     let database = { database.lock().await };
+    let chapter_storage = chapter_storage.lock().await;
     let token = create_token(cancel_token_store, cancel_id).await;
 
     let exclude = exclude.map(|v| {
@@ -276,11 +278,25 @@ async fn get_mangas(
             .collect::<Vec<_>>()
     });
 
-    let (mangas, errors) = cancel_after(&token.0, Duration::from_secs(59), |token| {
-        usecases::search_mangas(source_manager, &database, token, q, &exclude, 30)
+    let (mut mangas, errors) = cancel_after(&token.0, Duration::from_secs(59), |token| {
+        usecases::search_mangas(source_manager, &database, &chapter_storage, token, q, &exclude, 30)
     })
     .await
     .map_err(AppError::from_search_mangas_error)?;
+
+    for manga in mangas.iter_mut() {
+        if manga.information.cover_url.is_some() {
+            if let Some(path) = chapter_storage.poster_exists(&manga.information.id) {
+                manga.information.cover_url = match url::Url::from_file_path(&path) {
+                    Ok(url) => Some(url),
+                    Err(_) => match url::Url::from_file_path(path.canonicalize().unwrap()) {
+                        Ok(url) => Some(url),
+                        Err(_) => None,
+                    },
+                };
+            }
+        }
+    }
 
     let results = mangas.into_iter().map(Manga::from).collect();
 

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -264,7 +264,7 @@ async fn get_mangas(
 ) -> Result<Json<(Vec<Manga>, Vec<usecases::search_mangas::SearchError>)>, AppError> {
     let source_manager = { &*source_manager.lock().await };
     let database = { database.lock().await };
-    let chapter_storage = chapter_storage.lock().await;
+    let chapter_storage = chapter_storage.lock().await.clone();
     let token = create_token(cancel_token_store, cancel_id).await;
 
     let exclude = exclude.map(|v| {

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -18,7 +18,13 @@ use crate::AppError;
 fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
     match url::Url::from_file_path(&path) {
         Ok(url) => Some(url),
-        Err(_) => match url::Url::from_file_path(path.canonicalize().unwrap()) {
+        Err(_) => match path.canonicalize() {
+            Ok(canonical_path) => url::Url::from_file_path(canonical_path).ok(),
+            Err(e) => {
+                println!("Error canonicalizing path: {}", e);
+                None
+            }
+        },
             Ok(url) => Some(url),
             Err(_) => {
                 println!("Error converting path to URL");

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -7,7 +7,6 @@ use futures::Future;
 use log::warn;
 use serde::{Deserialize, Serialize};
 use shared::model::{ChapterId, MangaId, NotificationInformation};
-use shared::settings::SearchViewMode;
 use shared::usecases;
 use tokio_util::sync::CancellationToken;
 
@@ -255,7 +254,6 @@ async fn get_mangas(
         source_manager,
         cancel_token_store,
         chapter_storage,
-        settings,
         ..
     }): StateExtractor<State>,
     Query(GetMangasQuery {
@@ -267,7 +265,6 @@ async fn get_mangas(
     let source_manager = { &*source_manager.lock().await };
     let database = { database.lock().await };
     let chapter_storage = chapter_storage.lock().await;
-    let with_covers = settings.lock().await.search_view_mode != SearchViewMode::Base;
     let token = create_token(cancel_token_store, cancel_id).await;
 
     let exclude = exclude.map(|v| {
@@ -277,18 +274,16 @@ async fn get_mangas(
     });
 
     let (mut mangas, errors) = cancel_after(&token.0, Duration::from_secs(59), |token| {
-        usecases::search_mangas(source_manager, &database, &chapter_storage, token, q, &exclude, 30, with_covers)
+        usecases::search_mangas(source_manager, &database, &chapter_storage, token, q, &exclude, 30)
     })
     .await
     .map_err(AppError::from_search_mangas_error)?;
 
-    if with_covers {
-        for manga in mangas.iter_mut() {
-            if manga.information.cover_url.is_some() {
-                manga.information.cover_url = chapter_storage
-                    .poster_exists(&manga.information.id)
-                    .and_then(|path| path_to_file_url(&path));
-            }
+    for manga in mangas.iter_mut() {
+        if manga.information.cover_url.is_some() {
+            manga.information.cover_url = chapter_storage
+                .poster_exists(&manga.information.id)
+                .and_then(|path| path_to_file_url(&path));
         }
     }
 

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -15,6 +15,14 @@ use crate::source_extractor::SourceExtractor;
 use crate::state::State;
 use crate::AppError;
 
+fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
+    url::Url::from_file_path(path).ok().or_else(|| {
+        path.canonicalize()
+            .ok()
+            .and_then(|p| url::Url::from_file_path(p).ok())
+    })
+}
+
 pub fn routes() -> Router<State> {
     Router::new()
         .route("/library", get(get_manga_library))
@@ -112,22 +120,9 @@ async fn get_manga_library(
     if settings.library_view_mode != shared::settings::LibraryViewMode::Base {
         for manga in mangas.iter_mut() {
             if manga.information.cover_url.is_some() {
-                manga.information.cover_url = if let Some(path) =
-                    chapter_storage.poster_exists(&manga.information.id)
-                {
-                    match url::Url::from_file_path(&path) {
-                        Ok(url) => Some(url),
-                        Err(_) => match url::Url::from_file_path(path.canonicalize().unwrap()) {
-                            Ok(url) => Some(url),
-                            Err(_) => {
-                                println!("Error converting path to URL");
-                                None
-                            }
-                        },
-                    }
-                } else {
-                    None
-                };
+                manga.information.cover_url = chapter_storage
+                    .poster_exists(&manga.information.id)
+                    .and_then(|path| path_to_file_url(&path));
             }
         }
     }
@@ -286,15 +281,9 @@ async fn get_mangas(
 
     for manga in mangas.iter_mut() {
         if manga.information.cover_url.is_some() {
-            if let Some(path) = chapter_storage.poster_exists(&manga.information.id) {
-                manga.information.cover_url = match url::Url::from_file_path(&path) {
-                    Ok(url) => Some(url),
-                    Err(_) => match url::Url::from_file_path(path.canonicalize().unwrap()) {
-                        Ok(url) => Some(url),
-                        Err(_) => None,
-                    },
-                };
-            }
+            manga.information.cover_url = chapter_storage
+                .poster_exists(&manga.information.id)
+                .and_then(|path| path_to_file_url(&path));
         }
     }
 

--- a/backend/server/src/playlists/routes.rs
+++ b/backend/server/src/playlists/routes.rs
@@ -99,24 +99,21 @@ async fn get_mangas_in_playlist(
     if settings.library_view_mode != shared::settings::LibraryViewMode::Base {
         for manga in mangas.iter_mut() {
             if manga.information.cover_url.is_some() {
-                manga.information.cover_url = if let Some(path) =
-                    chapter_storage.poster_exists(&manga.information.id)
-                {
-                    match url::Url::from_file_path(&path) {
-                        Ok(url) => Some(url),
-                        Err(_) => match path.canonicalize() {
-                            Ok(canonical_path) => {
-                                url::Url::from_file_path(canonical_path).ok()
-                            }
-                            Err(e) => {
-                                println!("Error canonicalizing path: {}", e);
-                                None
-                            }
+                manga.information.cover_url =
+                    if let Some(path) = chapter_storage.poster_exists(&manga.information.id) {
+                        match url::Url::from_file_path(&path) {
+                            Ok(url) => Some(url),
+                            Err(_) => match path.canonicalize() {
+                                Ok(canonical_path) => url::Url::from_file_path(canonical_path).ok(),
+                                Err(e) => {
+                                    println!("Error canonicalizing path: {}", e);
+                                    None
+                                }
+                            },
                         }
-                    }
-                } else {
-                    None
-                };
+                    } else {
+                        None
+                    };
             }
         }
     }

--- a/backend/shared/benches/search_mangas_benchmark.rs
+++ b/backend/shared/benches/search_mangas_benchmark.rs
@@ -4,6 +4,7 @@ use pprof::criterion::{Output, PProfProfiler};
 use shared::{
     database::Database, settings::Settings, source_manager::SourceManager, usecases::search_mangas,
 };
+use size::Size;
 use std::sync::Arc;
 use std::{env, path::PathBuf};
 use tokio::sync::Mutex;
@@ -28,10 +29,18 @@ pub fn search_mangas_benchmark(c: &mut Criterion) {
         b.to_async(&runtime).iter(|| async {
             let db = Database::new(&PathBuf::from("test.db")).await.unwrap();
             let source_manager: &SourceManager = &arc_manager.blocking_lock();
+            let chapter_storage = shared::chapter_storage::ChapterStorage::new(
+                PathBuf::from("test.db"),
+                Size::from_mebibytes(100.0),
+            )
+            .unwrap();
+            let settings = Settings::default();
 
             search_mangas(
                 source_manager,
                 &db,
+                &chapter_storage,
+                &settings,
                 CancellationToken::new(),
                 query.clone(),
                 &None,

--- a/backend/shared/src/chapter_storage.rs
+++ b/backend/shared/src/chapter_storage.rs
@@ -114,22 +114,12 @@ impl ChapterStorage {
             } => result,
         }?;
 
-        let jpeg_bytes = {
-            let storage = self.clone();
-            tokio::task::spawn_blocking(move || storage.convert_image_data_to_jpeg(&bytes)).await??
-        };
-        tokio::fs::write(&file, &jpeg_bytes).await?;
+        tokio::fs::write(&file, &self.convert_image_data_to_jpeg(&bytes)?).await?;
 
         Ok(file)
     }
 
     fn convert_image_data_to_jpeg(&self, data: &[u8]) -> Result<Vec<u8>> {
-        // Maximum poster dimensions. Covers are displayed as small thumbnails so
-        // full-resolution originals are wasteful and can exceed KOReader's LRU
-        // image cache when loaded as raw bitmaps.
-        const MAX_WIDTH: u32 = 400;
-        const MAX_HEIGHT: u32 = 600;
-
         let (width, height, rgb_pixels) = {
             if let Some(data) = decode_image_fast(data) {
                 let image = data?;
@@ -165,24 +155,6 @@ impl ChapterStorage {
 
                 (width, height, rgb_img.to_vec())
             }
-        };
-
-        // Downscale to fit within MAX_WIDTH x MAX_HEIGHT, preserving aspect ratio.
-        let (width, height, rgb_pixels) = if width > MAX_WIDTH || height > MAX_HEIGHT {
-            let scale = (MAX_WIDTH as f32 / width as f32).min(MAX_HEIGHT as f32 / height as f32);
-            let new_width = ((width as f32 * scale).round() as u32).max(1);
-            let new_height = ((height as f32 * scale).round() as u32).max(1);
-            let img = image::RgbImage::from_raw(width, height, rgb_pixels)
-                .context("failed to build image buffer for resize")?;
-            let resized = image::imageops::resize(
-                &img,
-                new_width,
-                new_height,
-                image::imageops::FilterType::CatmullRom,
-            );
-            (new_width, new_height, resized.into_raw())
-        } else {
-            (width, height, rgb_pixels)
         };
 
         let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
@@ -451,56 +423,11 @@ mod tests {
     }
 
     #[test]
-    fn small_image_is_stored_unchanged() {
+    fn image_is_transcoded_to_jpeg() {
         let storage = make_storage();
         let input = make_rgb_jpeg(200, 300);
         let output = storage.convert_image_data_to_jpeg(&input).unwrap();
         let (w, h) = output_dimensions(&output);
         assert_eq!((w, h), (200, 300));
-    }
-
-    #[test]
-    fn wide_image_is_capped_at_max_width() {
-        let storage = make_storage();
-        // 1200x400 — wider than MAX_WIDTH (400), height within limit
-        let input = make_rgb_jpeg(1200, 400);
-        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
-        let (w, h) = output_dimensions(&output);
-        assert!(w <= 400, "width {w} exceeds MAX_WIDTH");
-        // Aspect ratio preserved: 1200/400 = 3.0, so h should be ~133
-        assert_eq!(w, 400);
-        assert_eq!(h, 133);
-    }
-
-    #[test]
-    fn tall_image_is_capped_at_max_height() {
-        let storage = make_storage();
-        // 200x1200 — taller than MAX_HEIGHT (600), width within limit
-        let input = make_rgb_jpeg(200, 1200);
-        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
-        let (w, h) = output_dimensions(&output);
-        assert!(h <= 600, "height {h} exceeds MAX_HEIGHT");
-        assert_eq!(h, 600);
-        assert_eq!(w, 100);
-    }
-
-    #[test]
-    fn large_portrait_cover_fits_within_bounds() {
-        let storage = make_storage();
-        // Typical high-res manga cover
-        let input = make_rgb_jpeg(1400, 2100);
-        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
-        let (w, h) = output_dimensions(&output);
-        assert!(w <= 400, "width {w} exceeds MAX_WIDTH");
-        assert!(h <= 600, "height {h} exceeds MAX_HEIGHT");
-    }
-
-    #[test]
-    fn exact_max_dimensions_are_not_resized() {
-        let storage = make_storage();
-        let input = make_rgb_jpeg(400, 600);
-        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
-        let (w, h) = output_dimensions(&output);
-        assert_eq!((w, h), (400, 600));
     }
 }

--- a/backend/shared/src/chapter_storage.rs
+++ b/backend/shared/src/chapter_storage.rs
@@ -120,13 +120,6 @@ impl ChapterStorage {
     }
 
     fn convert_image_data_to_jpeg(&self, data: &[u8]) -> Result<Vec<u8>> {
-        // KOReader's ImageCache is 8 MB total. Full-resolution covers (e.g. 800×1200)
-        // decode to ~3.8 MB each as raw bitmaps, exhausting the cache in 2-3 images.
-        // Cap at 400×600 so each cover stays under ~1 MB and the cache can hold a full
-        // page of search results without crashing.
-        const MAX_WIDTH: u32 = 400;
-        const MAX_HEIGHT: u32 = 600;
-
         let (width, height, rgb_pixels) = {
             if let Some(data) = decode_image_fast(data) {
                 let image = data?;
@@ -162,23 +155,6 @@ impl ChapterStorage {
 
                 (width, height, rgb_img.to_vec())
             }
-        };
-
-        let (width, height, rgb_pixels) = if width > MAX_WIDTH || height > MAX_HEIGHT {
-            let scale = (MAX_WIDTH as f32 / width as f32).min(MAX_HEIGHT as f32 / height as f32);
-            let new_width = ((width as f32 * scale).round() as u32).max(1);
-            let new_height = ((height as f32 * scale).round() as u32).max(1);
-            let img = image::RgbImage::from_raw(width, height, rgb_pixels)
-                .context("failed to build image buffer for resize")?;
-            let resized = image::imageops::resize(
-                &img,
-                new_width,
-                new_height,
-                image::imageops::FilterType::Triangle,
-            );
-            (new_width, new_height, resized.into_raw())
-        } else {
-            (width, height, rgb_pixels)
         };
 
         let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
@@ -423,7 +399,7 @@ mod tests {
 
     fn make_storage() -> ChapterStorage {
         let dir = tempdir().unwrap();
-        ChapterStorage::new(dir.into_path(), Size::from_mebibytes(100.0)).unwrap()
+        ChapterStorage::new(dir.keep(), Size::from_mebibytes(100.0)).unwrap()
     }
 
     fn make_rgb_jpeg(width: u32, height: u32) -> Vec<u8> {

--- a/backend/shared/src/chapter_storage.rs
+++ b/backend/shared/src/chapter_storage.rs
@@ -120,6 +120,13 @@ impl ChapterStorage {
     }
 
     fn convert_image_data_to_jpeg(&self, data: &[u8]) -> Result<Vec<u8>> {
+        // KOReader's ImageCache is 8 MB total. Full-resolution covers (e.g. 800×1200)
+        // decode to ~3.8 MB each as raw bitmaps, exhausting the cache in 2-3 images.
+        // Cap at 400×600 so each cover stays under ~1 MB and the cache can hold a full
+        // page of search results without crashing.
+        const MAX_WIDTH: u32 = 400;
+        const MAX_HEIGHT: u32 = 600;
+
         let (width, height, rgb_pixels) = {
             if let Some(data) = decode_image_fast(data) {
                 let image = data?;
@@ -155,6 +162,23 @@ impl ChapterStorage {
 
                 (width, height, rgb_img.to_vec())
             }
+        };
+
+        let (width, height, rgb_pixels) = if width > MAX_WIDTH || height > MAX_HEIGHT {
+            let scale = (MAX_WIDTH as f32 / width as f32).min(MAX_HEIGHT as f32 / height as f32);
+            let new_width = ((width as f32 * scale).round() as u32).max(1);
+            let new_height = ((height as f32 * scale).round() as u32).max(1);
+            let img = image::RgbImage::from_raw(width, height, rgb_pixels)
+                .context("failed to build image buffer for resize")?;
+            let resized = image::imageops::resize(
+                &img,
+                new_width,
+                new_height,
+                image::imageops::FilterType::Triangle,
+            );
+            (new_width, new_height, resized.into_raw())
+        } else {
+            (width, height, rgb_pixels)
         };
 
         let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);

--- a/backend/shared/src/chapter_storage.rs
+++ b/backend/shared/src/chapter_storage.rs
@@ -120,6 +120,12 @@ impl ChapterStorage {
     }
 
     fn convert_image_data_to_jpeg(&self, data: &[u8]) -> Result<Vec<u8>> {
+        // Maximum poster dimensions. Covers are displayed as small thumbnails so
+        // full-resolution originals are wasteful and can exceed KOReader's LRU
+        // image cache when loaded as raw bitmaps.
+        const MAX_WIDTH: u32 = 400;
+        const MAX_HEIGHT: u32 = 600;
+
         let (width, height, rgb_pixels) = {
             if let Some(data) = decode_image_fast(data) {
                 let image = data?;
@@ -155,6 +161,24 @@ impl ChapterStorage {
 
                 (width, height, rgb_img.to_vec())
             }
+        };
+
+        // Downscale to fit within MAX_WIDTH x MAX_HEIGHT, preserving aspect ratio.
+        let (width, height, rgb_pixels) = if width > MAX_WIDTH || height > MAX_HEIGHT {
+            let scale = (MAX_WIDTH as f32 / width as f32).min(MAX_HEIGHT as f32 / height as f32);
+            let new_width = ((width as f32 * scale).round() as u32).max(1);
+            let new_height = ((height as f32 * scale).round() as u32).max(1);
+            let img = image::RgbImage::from_raw(width, height, rgb_pixels)
+                .context("failed to build image buffer for resize")?;
+            let resized = image::imageops::resize(
+                &img,
+                new_width,
+                new_height,
+                image::imageops::FilterType::Triangle,
+            );
+            (new_width, new_height, resized.into_raw())
+        } else {
+            (width, height, rgb_pixels)
         };
 
         let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
@@ -388,5 +412,91 @@ impl ChapterStorage {
         let output_filename = format!("{}.{}", encoded_hash, if is_novel { "epub" } else { "cbz" });
 
         self.downloads_folder_path.join(output_filename)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use size::Size;
+    use tempfile::tempdir;
+
+    fn make_storage() -> ChapterStorage {
+        let dir = tempdir().unwrap();
+        ChapterStorage::new(dir.into_path(), Size::from_mebibytes(100.0)).unwrap()
+    }
+
+    fn make_rgb_jpeg(width: u32, height: u32) -> Vec<u8> {
+        let pixels: Vec<u8> = vec![128u8; (width * height * 3) as usize];
+        let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
+        comp.set_size(width as usize, height as usize);
+        comp.set_fastest_defaults();
+        let mut comp = comp.start_compress(Vec::new()).unwrap();
+        comp.write_scanlines(&pixels).unwrap();
+        comp.finish().unwrap()
+    }
+
+    fn output_dimensions(jpeg: &[u8]) -> (u32, u32) {
+        let cursor = std::io::Cursor::new(jpeg);
+        let img = image::ImageReader::new(cursor)
+            .with_guessed_format()
+            .unwrap()
+            .decode()
+            .unwrap();
+        (img.width(), img.height())
+    }
+
+    #[test]
+    fn small_image_is_stored_unchanged() {
+        let storage = make_storage();
+        let input = make_rgb_jpeg(200, 300);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert_eq!((w, h), (200, 300));
+    }
+
+    #[test]
+    fn wide_image_is_capped_at_max_width() {
+        let storage = make_storage();
+        // 1200x400 — wider than MAX_WIDTH (400), height within limit
+        let input = make_rgb_jpeg(1200, 400);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert!(w <= 400, "width {w} exceeds MAX_WIDTH");
+        // Aspect ratio preserved: 1200/400 = 3.0, so h should be ~133
+        assert_eq!(w, 400);
+        assert_eq!(h, 133);
+    }
+
+    #[test]
+    fn tall_image_is_capped_at_max_height() {
+        let storage = make_storage();
+        // 200x1200 — taller than MAX_HEIGHT (600), width within limit
+        let input = make_rgb_jpeg(200, 1200);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert!(h <= 600, "height {h} exceeds MAX_HEIGHT");
+        assert_eq!(h, 600);
+        assert_eq!(w, 100);
+    }
+
+    #[test]
+    fn large_portrait_cover_fits_within_bounds() {
+        let storage = make_storage();
+        // Typical high-res manga cover
+        let input = make_rgb_jpeg(1400, 2100);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert!(w <= 400, "width {w} exceeds MAX_WIDTH");
+        assert!(h <= 600, "height {h} exceeds MAX_HEIGHT");
+    }
+
+    #[test]
+    fn exact_max_dimensions_are_not_resized() {
+        let storage = make_storage();
+        let input = make_rgb_jpeg(400, 600);
+        let output = storage.convert_image_data_to_jpeg(&input).unwrap();
+        let (w, h) = output_dimensions(&output);
+        assert_eq!((w, h), (400, 600));
     }
 }

--- a/backend/shared/src/chapter_storage.rs
+++ b/backend/shared/src/chapter_storage.rs
@@ -178,7 +178,7 @@ impl ChapterStorage {
                 &img,
                 new_width,
                 new_height,
-                image::imageops::FilterType::Triangle,
+                image::imageops::FilterType::CatmullRom,
             );
             (new_width, new_height, resized.into_raw())
         } else {

--- a/backend/shared/src/chapter_storage.rs
+++ b/backend/shared/src/chapter_storage.rs
@@ -114,7 +114,11 @@ impl ChapterStorage {
             } => result,
         }?;
 
-        tokio::fs::write(&file, &self.convert_image_data_to_jpeg(&bytes)?).await?;
+        let jpeg_bytes = {
+            let storage = self.clone();
+            tokio::task::spawn_blocking(move || storage.convert_image_data_to_jpeg(&bytes)).await??
+        };
+        tokio::fs::write(&file, &jpeg_bytes).await?;
 
         Ok(file)
     }

--- a/backend/shared/src/settings/mod.rs
+++ b/backend/shared/src/settings/mod.rs
@@ -2,6 +2,6 @@ mod implementation;
 mod schema;
 
 pub use schema::{
-    ChapterSortingMode, LibrarySortingMode, LibraryViewMode, Settings, SourceSettingValue,
-    StorageSizeLimit,
+    ChapterSortingMode, LibrarySortingMode, LibraryViewMode, SearchViewMode, Settings,
+    SourceSettingValue, StorageSizeLimit,
 };

--- a/backend/shared/src/settings/schema.rs
+++ b/backend/shared/src/settings/schema.rs
@@ -57,6 +57,15 @@ pub enum LibraryViewMode {
     Grid,
 }
 
+#[derive(Copy, Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchViewMode {
+    #[default]
+    Base,
+    Cover,
+    Grid,
+}
+
 /// Settings used to configure rakuyomi's behavior.
 #[derive(Serialize, Deserialize, Default, Clone, Debug, JsonSchema)]
 pub struct Settings {
@@ -114,6 +123,9 @@ pub struct Settings {
 
     #[serde(default)]
     pub library_view_mode: LibraryViewMode,
+
+    #[serde(default)]
+    pub search_view_mode: SearchViewMode,
 }
 
 fn default_storage_size_limit() -> StorageSizeLimit {

--- a/backend/shared/src/usecases/search_mangas.rs
+++ b/backend/shared/src/usecases/search_mangas.rs
@@ -13,6 +13,7 @@ use unicode_normalization::UnicodeNormalization;
 
 const CONCURRENT_SEARCH_REQUESTS: usize = 5;
 const CONCURRENT_POSTER_DOWNLOADS: usize = 4;
+const POSTER_DOWNLOAD_TIMEOUT_SECS: u64 = 10;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct SearchError {
@@ -126,11 +127,13 @@ pub async fn search_mangas(
                             let source = source.clone();
                             let token = token.clone();
                             async move {
-                                let _ = chapter_storage
-                                    .cached_poster(&token, &id, || {
+                                let _ = timeout(
+                                    Duration::from_secs(POSTER_DOWNLOAD_TIMEOUT_SECS),
+                                    chapter_storage.cached_poster(&token, &id, || {
                                         source.get_image_request(url.clone(), None)
-                                    })
-                                    .await;
+                                    }),
+                                )
+                                .await;
                             }
                         })
                         .buffered(CONCURRENT_POSTER_DOWNLOADS)

--- a/backend/shared/src/usecases/search_mangas.rs
+++ b/backend/shared/src/usecases/search_mangas.rs
@@ -28,7 +28,6 @@ pub async fn search_mangas(
     query: String,
     exclude: &Option<Vec<String>>,
     seconds: u64,
-    with_covers: bool,
 ) -> Result<(Vec<Manga>, Vec<SearchError>), Error> {
     // FIXME this looks awful
     let query = &query;
@@ -115,30 +114,28 @@ pub async fn search_mangas(
                         .await;
 
                     // Download posters concurrently so cover/grid view can render them
-                    if with_covers {
-                        let poster_items: Vec<(MangaId, url::Url)> = manga_informations
-                            .iter()
-                            .filter_map(|info| {
-                                info.cover_url.as_ref().map(|url| (info.id.clone(), url.clone()))
-                            })
-                            .collect();
-                        stream::iter(poster_items)
-                            .map(|(id, url)| {
-                                let chapter_storage = chapter_storage.clone();
-                                let source = source.clone();
-                                let token = token.clone();
-                                async move {
-                                    let _ = chapter_storage
-                                        .cached_poster(&token, &id, || {
-                                            source.get_image_request(url.clone(), None)
-                                        })
-                                        .await;
-                                }
-                            })
-                            .buffered(CONCURRENT_POSTER_DOWNLOADS)
-                            .collect::<Vec<_>>()
-                            .await;
-                    }
+                    let poster_items: Vec<(MangaId, url::Url)> = manga_informations
+                        .iter()
+                        .filter_map(|info| {
+                            info.cover_url.as_ref().map(|url| (info.id.clone(), url.clone()))
+                        })
+                        .collect();
+                    stream::iter(poster_items)
+                        .map(|(id, url)| {
+                            let chapter_storage = chapter_storage.clone();
+                            let source = source.clone();
+                            let token = token.clone();
+                            async move {
+                                let _ = chapter_storage
+                                    .cached_poster(&token, &id, || {
+                                        source.get_image_request(url.clone(), None)
+                                    })
+                                    .await;
+                            }
+                        })
+                        .buffered(CONCURRENT_POSTER_DOWNLOADS)
+                        .collect::<Vec<_>>()
+                        .await;
 
                     // Fetch unread chapters count for each manga
                     let manga_ids: Vec<_> =

--- a/backend/shared/src/usecases/search_mangas.rs
+++ b/backend/shared/src/usecases/search_mangas.rs
@@ -1,4 +1,5 @@
 use crate::{
+    chapter_storage::ChapterStorage,
     database::Database,
     model::{Manga, MangaInformation, MangaState, SourceInformation},
     source_collection::SourceCollection,
@@ -21,6 +22,7 @@ pub struct SearchError {
 pub async fn search_mangas(
     source_collection: &impl SourceCollection,
     db: &Database,
+    chapter_storage: &ChapterStorage,
     cancellation_token: CancellationToken,
     query: String,
     exclude: &Option<Vec<String>>,
@@ -44,6 +46,7 @@ pub async fn search_mangas(
             .map(|source| {
                 let cancellation_token = cancellation_token.clone();
                 let query = query.to_string();
+                let chapter_storage = chapter_storage.clone();
 
                 async move {
                     if exclude
@@ -108,6 +111,18 @@ pub async fn search_mangas(
                     let _ = db
                         .upsert_cached_manga_information(&manga_informations)
                         .await;
+
+                    // Download posters for each result so cover/grid view can render them
+                    for info in &manga_informations {
+                        if let Some(cover_url) = &info.cover_url {
+                            let url = cover_url.clone();
+                            let _ = chapter_storage
+                                .cached_poster(&token, &info.id, || {
+                                    source.get_image_request(url.clone(), None)
+                                })
+                                .await;
+                        }
+                    }
 
                     // Fetch unread chapters count for each manga
                     let manga_ids: Vec<_> =

--- a/backend/shared/src/usecases/search_mangas.rs
+++ b/backend/shared/src/usecases/search_mangas.rs
@@ -2,6 +2,7 @@ use crate::{
     chapter_storage::ChapterStorage,
     database::Database,
     model::{Manga, MangaId, MangaInformation, MangaState, SourceInformation},
+    settings::{SearchViewMode, Settings},
     source_collection::SourceCollection,
 };
 use futures::{stream, StreamExt};
@@ -25,6 +26,7 @@ pub async fn search_mangas(
     source_collection: &impl SourceCollection,
     db: &Database,
     chapter_storage: &ChapterStorage,
+    settings: &Settings,
     cancellation_token: CancellationToken,
     query: String,
     exclude: &Option<Vec<String>>,
@@ -114,31 +116,35 @@ pub async fn search_mangas(
                         .upsert_cached_manga_information(&manga_informations)
                         .await;
 
-                    // Download posters concurrently so cover/grid view can render them
-                    let poster_items: Vec<(MangaId, url::Url)> = manga_informations
-                        .iter()
-                        .filter_map(|info| {
-                            info.cover_url.as_ref().map(|url| (info.id.clone(), url.clone()))
-                        })
-                        .collect();
-                    stream::iter(poster_items)
-                        .map(|(id, url)| {
-                            let chapter_storage = chapter_storage.clone();
-                            let source = source.clone();
-                            let token = token.clone();
-                            async move {
-                                let _ = timeout(
-                                    Duration::from_secs(POSTER_DOWNLOAD_TIMEOUT_SECS),
-                                    chapter_storage.cached_poster(&token, &id, || {
-                                        source.get_image_request(url.clone(), None)
-                                    }),
-                                )
-                                .await;
-                            }
-                        })
-                        .buffered(CONCURRENT_POSTER_DOWNLOADS)
-                        .collect::<Vec<_>>()
-                        .await;
+                    if settings.search_view_mode != SearchViewMode::Base {
+                        // Download posters concurrently so cover/grid view can render them
+                        let poster_items: Vec<(MangaId, url::Url)> = manga_informations
+                            .iter()
+                            .filter_map(|info| {
+                                info.cover_url
+                                    .as_ref()
+                                    .map(|url| (info.id.clone(), url.clone()))
+                            })
+                            .collect();
+                        stream::iter(poster_items)
+                            .map(|(id, url)| {
+                                let chapter_storage = chapter_storage.clone();
+                                let source = source.clone();
+                                let token = token.clone();
+                                async move {
+                                    let _ = timeout(
+                                        Duration::from_secs(POSTER_DOWNLOAD_TIMEOUT_SECS),
+                                        chapter_storage.cached_poster(&token, &id, || {
+                                            source.get_image_request(url.clone(), None)
+                                        }),
+                                    )
+                                    .await;
+                                }
+                            })
+                            .buffered(CONCURRENT_POSTER_DOWNLOADS)
+                            .collect::<Vec<_>>()
+                            .await;
+                    }
 
                     // Fetch unread chapters count for each manga
                     let manga_ids: Vec<_> =

--- a/backend/shared/src/usecases/search_mangas.rs
+++ b/backend/shared/src/usecases/search_mangas.rs
@@ -1,7 +1,7 @@
 use crate::{
     chapter_storage::ChapterStorage,
     database::Database,
-    model::{Manga, MangaInformation, MangaState, SourceInformation},
+    model::{Manga, MangaId, MangaInformation, MangaState, SourceInformation},
     source_collection::SourceCollection,
 };
 use futures::{stream, StreamExt};
@@ -12,6 +12,7 @@ use tokio_util::sync::CancellationToken;
 use unicode_normalization::UnicodeNormalization;
 
 const CONCURRENT_SEARCH_REQUESTS: usize = 5;
+const CONCURRENT_POSTER_DOWNLOADS: usize = 4;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct SearchError {
@@ -112,17 +113,29 @@ pub async fn search_mangas(
                         .upsert_cached_manga_information(&manga_informations)
                         .await;
 
-                    // Download posters for each result so cover/grid view can render them
-                    for info in &manga_informations {
-                        if let Some(cover_url) = &info.cover_url {
-                            let url = cover_url.clone();
+                    // Download posters concurrently so cover/grid view can render them
+                    let poster_items: Vec<(MangaId, url::Url)> = manga_informations
+                        .iter()
+                        .filter_map(|info| {
+                            info.cover_url.as_ref().map(|url| (info.id.clone(), url.clone()))
+                        })
+                        .collect();
+                    stream::iter(poster_items)
+                    .map(|(id, url)| {
+                        let chapter_storage = chapter_storage.clone();
+                        let source = source.clone();
+                        let token = token.clone();
+                        async move {
                             let _ = chapter_storage
-                                .cached_poster(&token, &info.id, || {
+                                .cached_poster(&token, &id, || {
                                     source.get_image_request(url.clone(), None)
                                 })
                                 .await;
                         }
-                    }
+                    })
+                    .buffered(CONCURRENT_POSTER_DOWNLOADS)
+                    .collect::<Vec<_>>()
+                    .await;
 
                     // Fetch unread chapters count for each manga
                     let manga_ids: Vec<_> =

--- a/backend/shared/src/usecases/search_mangas.rs
+++ b/backend/shared/src/usecases/search_mangas.rs
@@ -28,6 +28,7 @@ pub async fn search_mangas(
     query: String,
     exclude: &Option<Vec<String>>,
     seconds: u64,
+    with_covers: bool,
 ) -> Result<(Vec<Manga>, Vec<SearchError>), Error> {
     // FIXME this looks awful
     let query = &query;
@@ -114,28 +115,30 @@ pub async fn search_mangas(
                         .await;
 
                     // Download posters concurrently so cover/grid view can render them
-                    let poster_items: Vec<(MangaId, url::Url)> = manga_informations
-                        .iter()
-                        .filter_map(|info| {
-                            info.cover_url.as_ref().map(|url| (info.id.clone(), url.clone()))
-                        })
-                        .collect();
-                    stream::iter(poster_items)
-                    .map(|(id, url)| {
-                        let chapter_storage = chapter_storage.clone();
-                        let source = source.clone();
-                        let token = token.clone();
-                        async move {
-                            let _ = chapter_storage
-                                .cached_poster(&token, &id, || {
-                                    source.get_image_request(url.clone(), None)
-                                })
-                                .await;
-                        }
-                    })
-                    .buffered(CONCURRENT_POSTER_DOWNLOADS)
-                    .collect::<Vec<_>>()
-                    .await;
+                    if with_covers {
+                        let poster_items: Vec<(MangaId, url::Url)> = manga_informations
+                            .iter()
+                            .filter_map(|info| {
+                                info.cover_url.as_ref().map(|url| (info.id.clone(), url.clone()))
+                            })
+                            .collect();
+                        stream::iter(poster_items)
+                            .map(|(id, url)| {
+                                let chapter_storage = chapter_storage.clone();
+                                let source = source.clone();
+                                let token = token.clone();
+                                async move {
+                                    let _ = chapter_storage
+                                        .cached_poster(&token, &id, || {
+                                            source.get_image_request(url.clone(), None)
+                                        })
+                                        .await;
+                                }
+                            })
+                            .buffered(CONCURRENT_POSTER_DOWNLOADS)
+                            .collect::<Vec<_>>()
+                            .await;
+                    }
 
                     // Fetch unread chapters count for each manga
                     let manga_ids: Vec<_> =

--- a/backend/shared/src/usecases/update_settings.rs
+++ b/backend/shared/src/usecases/update_settings.rs
@@ -5,7 +5,8 @@ use serde::{Deserialize, Serialize};
 use size::{consts, Size};
 
 use crate::settings::{
-    ChapterSortingMode, LibrarySortingMode, LibraryViewMode, Settings, StorageSizeLimit,
+    ChapterSortingMode, LibrarySortingMode, LibraryViewMode, SearchViewMode, Settings,
+    StorageSizeLimit,
 };
 
 pub fn update_settings(
@@ -37,6 +38,7 @@ pub struct UpdateableSettings {
     preload_chapters: usize,
     optimize_image: bool,
     library_view_mode: LibraryViewMode,
+    search_view_mode: SearchViewMode,
 }
 
 impl UpdateableSettings {
@@ -53,6 +55,7 @@ impl UpdateableSettings {
         settings.preload_chapters = self.preload_chapters;
         settings.optimize_image = self.optimize_image;
         settings.library_view_mode = self.library_view_mode;
+        settings.search_view_mode = self.search_view_mode;
     }
 }
 
@@ -72,6 +75,7 @@ impl From<&Settings> for UpdateableSettings {
             preload_chapters: value.preload_chapters,
             optimize_image: value.optimize_image,
             library_view_mode: value.library_view_mode,
+            search_view_mode: value.search_view_mode,
         }
     }
 }

--- a/e2e-tests/tests/test_search_view_modes.py
+++ b/e2e-tests/tests/test_search_view_modes.py
@@ -1,0 +1,81 @@
+import time
+from typing import Literal
+
+from pydantic import BaseModel
+
+from . import queries
+from .queries.locate_button import LocateButtonResponse
+from .koreader_driver import KOReaderDriver
+
+
+class SearchViewModeResponse(BaseModel):
+    mode: Literal['base', 'cover', 'grid']
+
+
+async def get_search_view_mode(driver: KOReaderDriver) -> str:
+    response = await driver.query(
+        "What is the current view mode of the search results? "
+        "Reply with 'base' if items are shown as a plain text list with no images, "
+        "'cover' if items show cover art on the left side next to text, "
+        "or 'grid' if items are arranged in multiple columns each showing cover art.",
+        SearchViewModeResponse,
+    )
+    return response.mode
+
+
+async def open_search(driver: KOReaderDriver, query: str) -> None:
+    menu_button = await queries.locate_button(driver, "menu")
+    driver.click_element(menu_button)
+
+    search_button = await queries.locate_button(driver, "Search")
+    driver.click_element(search_button)
+    time.sleep(1)
+
+    driver.type(query)
+    search_button = await queries.locate_button(driver, "Search")
+    driver.click_element(search_button)
+
+    await driver.wait_for_event('manga_search_results_shown')
+
+
+async def test_search_view_modes(koreader_driver: KOReaderDriver):
+    await koreader_driver.install_source('multi.batoto')
+    await koreader_driver.open_library_view()
+
+    # Open an initial search
+    await open_search(koreader_driver, 'houseki no kuni')
+
+    # Default should be base (list) view
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'base', f"Expected default view mode 'base', got '{mode}'"
+
+    # Tap toggle → cover
+    toggle = await koreader_driver.query(
+        "Locate the view mode toggle icon button in the top left corner of the title bar",
+        LocateButtonResponse,
+    )
+    koreader_driver.click_element(toggle)
+    await koreader_driver.wait_for_event('search_view_mode_changed')
+
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'cover', f"Expected view mode 'cover', got '{mode}'"
+
+    # Tap toggle → grid
+    toggle = await koreader_driver.query(
+        "Locate the view mode toggle icon button in the top left corner of the title bar",
+        LocateButtonResponse,
+    )
+    koreader_driver.click_element(toggle)
+    await koreader_driver.wait_for_event('search_view_mode_changed')
+
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'grid', f"Expected view mode 'grid', got '{mode}'"
+
+    # Close search and reopen — mode should persist
+    back_button = await queries.locate_button(koreader_driver, "Back")
+    koreader_driver.click_element(back_button)
+
+    await open_search(koreader_driver, 'houseki no kuni')
+
+    mode = await get_search_view_mode(koreader_driver)
+    assert mode == 'grid', f"Expected persisted view mode 'grid', got '{mode}'"

--- a/frontend/rakuyomi.koplugin/Backend.lua
+++ b/frontend/rakuyomi.koplugin/Backend.lua
@@ -567,7 +567,8 @@ end
 
 --- @alias ChapterSortingMode 'chapter_ascending'|'chapter_descending'
 --- @alias LibraryViewMode 'base' | 'cover' | 'grid'
---- @class Settings: { chapter_sorting_mode: ChapterSortingMode, preload_chapters: number, library_view_mode: LibraryViewMode }
+--- @alias SearchViewMode 'base' | 'cover' | 'grid'
+--- @class Settings: { chapter_sorting_mode: ChapterSortingMode, preload_chapters: number, library_view_mode: LibraryViewMode, search_view_mode: SearchViewMode }
 
 --- Reads the application settings.
 --- @return SuccessfulResponse<Settings>|ErrorResponse

--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -50,7 +50,6 @@ function MangaSearchResults:init()
   self.height = Screen:getHeight()
   local page = self.page
   Menu.init(self)
-  MenuCustom.init(self)
   self.page = page
 
   self.paths = { 0 }

--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -39,7 +39,8 @@ function MangaSearchResults:init()
   -- in our explicit updateItems() below, exhausting the LRU image cache.
   local results = self.results or {}
   self.results = {}
-  self.search_view_mode = G_reader_settings:readSetting("rakuyomi_search_view_mode", "base")
+  local settings_response = Backend.getSettings()
+  self.search_view_mode = (settings_response.type ~= 'ERROR' and settings_response.body.search_view_mode) or "base"
 
   self.title_bar_left_icon = "column.two"
   self.onLeftButtonTap = function()
@@ -68,7 +69,11 @@ function MangaSearchResults:cycleViewMode()
     end
   end
   self.search_view_mode = next_mode
-  G_reader_settings:saveSetting("rakuyomi_search_view_mode", next_mode)
+  local settings_response = Backend.getSettings()
+  if settings_response.type ~= 'ERROR' then
+    settings_response.body.search_view_mode = next_mode
+    Backend.setSettings(settings_response.body)
+  end
   self:updateItems()
   Testing:emitEvent("search_view_mode_changed", { mode = next_mode })
 end
@@ -95,7 +100,7 @@ function MangaSearchResults:updateItems()
 
   local mode = self.search_view_mode
   if mode == "grid" then
-    self.grid_columns = G_reader_settings:readSetting("rakuyomi_grid_columns") or 3
+    self.grid_columns = 3
     MenuCustom.updateItems(self, MenuItemGrid)
   elseif mode == "cover" then
     self.grid_columns = nil
@@ -274,7 +279,7 @@ function MangaSearchResults:onContextMenuChoice(item)
             local added = manga.in_library
             manga.in_library = not added
 
-            if manga.in_library and self.search_view_mode ~= 'base' then
+            if manga.in_library and Backend.getSettings().body.library_view_mode ~= 'base' then
               local cancel_id = Backend.createCancelId()
               local response, cancelled = LoadingDialog:showAndRun(
                 _("Refreshing details..."),

--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -8,6 +8,9 @@ local addToPlaylist = require("handlers/addToPlaylist")
 local Backend = require("Backend")
 local ErrorDialog = require("ErrorDialog")
 local Menu = require("widgets/Menu")
+local MenuCustom = require("patch/MenuCustom")
+local MenuItemCover = require("patch/MenuItemCover")
+local MenuItemGrid = require("patch/MenuItemGrid")
 local LoadingDialog = require("LoadingDialog")
 local ChapterListing = require("ChapterListing")
 local Testing = require("testing")
@@ -19,33 +22,64 @@ local Trapper = require("ui/trapper")
 --- @class MangaSearchResults: { [any]: any }
 --- @field results Manga[]
 --- @field on_return_callback fun(): nil
-local MangaSearchResults = Menu:extend {
+local MangaSearchResults = MenuCustom:extend {
   name = "manga_search_results",
   is_enable_shortcut = false,
   is_popout = false,
   title = _("Search results..."),
   with_context_menu = true,
 
-  -- list of mangas
   results = nil,
-  -- callback to be called when pressing the back button
   on_return_callback = nil,
 }
 
 function MangaSearchResults:init()
-  self.results = self.results or {}
+  -- Stash results before Menu.init so its internal updateItems() call sees an
+  -- empty list. Without this, covers are loaded once inside Menu.init and again
+  -- in our explicit updateItems() below, exhausting the LRU image cache.
+  local results = self.results or {}
+  self.results = {}
+  self.search_view_mode = G_reader_settings:readSetting("rakuyomi_search_view_mode", "base")
+
+  self.title_bar_left_icon = "column.two"
+  self.onLeftButtonTap = function()
+    self:cycleViewMode()
+  end
+
   self.width = Screen:getWidth()
   self.height = Screen:getHeight()
   local page = self.page
   Menu.init(self)
+  MenuCustom.init(self)
   self.page = page
 
-  -- see `ChapterListing` for an explanation on this
-  -- FIXME we could refactor this into a single class
   self.paths = { 0 }
   self.on_return_callback = nil
+  self.results = results
+  self:updateItems()
+end
 
-  -- self:updateItems()
+function MangaSearchResults:cycleViewMode()
+  local modes = { "base", "cover", "grid" }
+  local next_mode = "base"
+  for i, mode in ipairs(modes) do
+    if mode == self.search_view_mode then
+      next_mode = modes[(i % #modes) + 1]
+      break
+    end
+  end
+  self.search_view_mode = next_mode
+  G_reader_settings:saveSetting("rakuyomi_search_view_mode", next_mode)
+  self:updateItems()
+  Testing:emitEvent("search_view_mode_changed", { mode = next_mode })
+end
+
+function MangaSearchResults:_recalculateDimen(flag)
+  if self.search_view_mode ~= "base" then
+    MenuCustom._recalculateDimen(self, flag)
+  else
+    Menu._recalculateDimen(self, flag)
+  end
 end
 
 function MangaSearchResults:onClose()
@@ -60,7 +94,17 @@ end
 function MangaSearchResults:updateItems()
   self.item_table = self:generateItemTableFromSearchResults(self.results)
 
-  Menu.updateItems(self)
+  local mode = self.search_view_mode
+  if mode == "grid" then
+    self.grid_columns = G_reader_settings:readSetting("rakuyomi_grid_columns") or 3
+    MenuCustom.updateItems(self, MenuItemGrid)
+  elseif mode == "cover" then
+    self.grid_columns = nil
+    MenuCustom.updateItems(self, MenuItemCover)
+  else
+    self.grid_columns = nil
+    Menu.updateItems(self)
+  end
 end
 
 --- Generates the item table for displaying the search results.
@@ -69,22 +113,25 @@ end
 --- @return table
 function MangaSearchResults:generateItemTableFromSearchResults(results)
   local item_table = {}
+  local is_cover = self.search_view_mode == "cover"
+
   for _, manga in ipairs(results) do
     local mandatory = (manga.last_read and calcLastReadText(manga.last_read) .. " " or "")
 
     if manga.unread_chapters_count ~= nil and manga.unread_chapters_count > 0 then
-      mandatory = (mandatory or "") .. Icons.FA_BELL .. manga.unread_chapters_count
+      mandatory = mandatory .. Icons.FA_BELL .. manga.unread_chapters_count
     end
 
     if manga.in_library then
-      mandatory = (mandatory or "") .. Icons.COD_LIBRARY
+      mandatory = mandatory .. Icons.COD_LIBRARY
     end
 
     table.insert(item_table, {
       manga = manga,
       text = manga.title,
-      post_text = manga.source.name,
-      mandatory = mandatory,
+      post_text = is_cover and mandatory or manga.source.name,
+      manga_cover = self.search_view_mode ~= "base" and manga.manga_cover or nil,
+      mandatory = not is_cover and mandatory or nil,
     })
   end
 
@@ -228,7 +275,7 @@ function MangaSearchResults:onContextMenuChoice(item)
             local added = manga.in_library
             manga.in_library = not added
 
-            if manga.in_library and Backend.getSettings().body.library_view_mode ~= 'base' then
+            if manga.in_library and self.search_view_mode ~= 'base' then
               local cancel_id = Backend.createCancelId()
               local response, cancelled = LoadingDialog:showAndRun(
                 _("Refreshing details..."),
@@ -284,11 +331,11 @@ function MangaSearchResults:onContextMenuChoice(item)
             local onReturnCallback = function()
               local ui = MangaSearchResults:new {
                 results = self.results,
-                on_return_callback = self.onReturnCallback,
+                on_return_callback = self.on_return_callback,
                 covers_fullscreen = true, -- hint for UIManager:_repaint()
                 page = self.page
               }
-              ui.on_return_callback = self.onReturnCallback
+              ui.on_return_callback = self.on_return_callback
               UIManager:show(ui)
             end
             MangaInfoWidget:fetchAndShow(manga, onReturnCallback)

--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -29,16 +29,14 @@ local MangaSearchResults = MenuCustom:extend {
   title = _("Search results..."),
   with_context_menu = true,
 
+  -- list of mangas
   results = nil,
+  -- callback to be called when pressing the back button
   on_return_callback = nil,
 }
 
 function MangaSearchResults:init()
-  -- Stash results before Menu.init so its internal updateItems() call sees an
-  -- empty list. Without this, covers are loaded once inside Menu.init and again
-  -- in our explicit updateItems() below, exhausting the LRU image cache.
   local results = self.results or {}
-  self.results = {}
   local settings_response = Backend.getSettings()
   self.search_view_mode = (settings_response.type ~= 'ERROR' and settings_response.body.search_view_mode) or "base"
 
@@ -53,6 +51,8 @@ function MangaSearchResults:init()
   Menu.init(self)
   self.page = page
 
+  -- see `ChapterListing` for an explanation on this
+  -- FIXME we could refactor this into a single class
   self.paths = { 0 }
   self.on_return_callback = nil
   self.results = results
@@ -99,14 +99,17 @@ function MangaSearchResults:updateItems()
   self.item_table = self:generateItemTableFromSearchResults(self.results)
 
   local mode = self.search_view_mode
+  local MenuItemChoice = MenuItemCover
   if mode == "grid" then
-    self.grid_columns = 3
-    MenuCustom.updateItems(self, MenuItemGrid)
-  elseif mode == "cover" then
-    self.grid_columns = nil
-    MenuCustom.updateItems(self, MenuItemCover)
+    MenuItemChoice = MenuItemGrid
+    self.grid_columns = G_reader_settings:readSetting("rakuyomi_grid_columns") or 3
   else
     self.grid_columns = nil
+  end
+
+  if mode ~= "base" then
+    MenuCustom.updateItems(self, MenuItemChoice)
+  else
     Menu.updateItems(self)
   end
 end

--- a/frontend/rakuyomi.koplugin/Settings.lua
+++ b/frontend/rakuyomi.koplugin/Settings.lua
@@ -107,7 +107,7 @@ Settings.setting_value_definitions = {
     { type = 'divider', title = _("Search") }
   },
   {
-    'rakuyomi_search_view_mode',
+    'search_view_mode',
     {
       type = 'enum',
       title = _("Search view mode"),
@@ -116,7 +116,6 @@ Settings.setting_value_definitions = {
         { label = _("Cover"), value = "cover" },
         { label = _("Grid"),  value = "grid" },
       },
-      is_local = true,
       default = "base",
     }
   },

--- a/frontend/rakuyomi.koplugin/Settings.lua
+++ b/frontend/rakuyomi.koplugin/Settings.lua
@@ -104,6 +104,24 @@ Settings.setting_value_definitions = {
   },
   {
     nil,
+    { type = 'divider', title = _("Search") }
+  },
+  {
+    'rakuyomi_search_view_mode',
+    {
+      type = 'enum',
+      title = _("Search view mode"),
+      options = {
+        { label = _("Base"),  value = "base" },
+        { label = _("Cover"), value = "cover" },
+        { label = _("Grid"),  value = "grid" },
+      },
+      is_local = true,
+      default = "base",
+    }
+  },
+  {
+    nil,
     { type = 'divider', title = _("Reader") }
   },
   {

--- a/frontend/rakuyomi.koplugin/patch/MenuCustom.lua
+++ b/frontend/rakuyomi.koplugin/patch/MenuCustom.lua
@@ -40,7 +40,7 @@ function MenuCustom:updateItems(MenuItem, select_number, no_recalculate_dimen)
 
   local columns = self.grid_columns or 1
   if columns > 1 then
-    local rows = math.floor(items_nb / columns)
+    local rows = math.ceil(items_nb / columns)
     for r = 1, rows do
       local row_group = HorizontalGroup:new { align = "center" }
       for c = 1, columns do

--- a/frontend/rakuyomi.koplugin/patch/MenuItemCover.lua
+++ b/frontend/rakuyomi.koplugin/patch/MenuItemCover.lua
@@ -429,8 +429,11 @@ function MenuItemCover:genCover(wleft_width, wleft_height)
 
   local wleft
   if self.entry.manga_cover and starts_with(self.entry.manga_cover, "file://") then
+    local cover_path = self.entry.manga_cover:gsub("^file://", ""):gsub("%%(%x%x)", function(hex)
+      return string.char(tonumber(hex, 16))
+    end)
     local wimage = ImageWidget:new {
-      file = self.entry.manga_cover:gsub("^file://", ""),
+      file = cover_path,
       -- scale_factor = 0.5
     }
     wimage:_loadfile()
@@ -438,7 +441,7 @@ function MenuItemCover:genCover(wleft_width, wleft_height)
     local _, _, scale_factor = getCachedCoverSize(image_size.w, image_size.h, wleft_width, wleft_height)
 
     wimage = ImageWidget:new {
-      file = self.entry.manga_cover:gsub("^file://", ""),
+      file = cover_path,
       scale_factor = scale_factor
     }
 

--- a/frontend/rakuyomi.koplugin/patch/MenuItemCover.lua
+++ b/frontend/rakuyomi.koplugin/patch/MenuItemCover.lua
@@ -434,7 +434,7 @@ function MenuItemCover:genCover(wleft_width, wleft_height)
     end)
     local wimage = ImageWidget:new {
       file = cover_path,
-      -- scale_factor = 0.5
+      file_do_cache = false,
     }
     wimage:_loadfile()
     local image_size = wimage:getSize() -- get final widget size
@@ -442,7 +442,8 @@ function MenuItemCover:genCover(wleft_width, wleft_height)
 
     wimage = ImageWidget:new {
       file = cover_path,
-      scale_factor = scale_factor
+      scale_factor = scale_factor,
+      file_do_cache = false,
     }
 
     wimage:_render()


### PR DESCRIPTION
## Summary

- Adds cover and grid view modes to the manga search results screen, mirroring the existing library view
- A toggle icon in the title bar cycles between list → cover → grid → list; the same setting is also accessible from the plugin settings menu
- View mode persists across sessions via backend settings (`search_view_mode`, default: `base`)
- Posters are downloaded during search so cover/grid renders without requiring the manga to be opened first
- Poster dimensions are capped at 400×600 on download to prevent KOReader's LRU image cache from overflowing on large source images
- Cover images are excluded from KOReader's 8 MB `ImageCache` (`file_do_cache = false`) — they are transient per-search results already persisted to disk in `.posters/`, so caching them in an icon cache designed for reusable UI elements caused LRU crashes and crowded out icons

https://github.com/user-attachments/assets/ea5f0729-b6a3-43f9-9228-6bbd4f9eb7e6

## Resize filter: CatmullRom → Triangle

The poster resize uses `Triangle` (bilinear) instead of `CatmullRom`. For thumbnail-sized output (≤ 400×600) the quality difference is imperceptible, but the performance difference is significant — especially on Kindle where CPU is much slower than desktop.

### Benchmark methodology

Benchmarks were run using [Criterion](https://github.com/bheisler/criterion.rs), a statistical benchmarking library for Rust. Each filter was measured in isolation (JPEG decode excluded) across three representative cover sizes. Criterion runs a 3-second warm-up phase to stabilise CPU cache state, then collects 100+ samples and reports a confidence interval.

### Results (macOS, optimised build)

| Cover size | CatmullRom | Triangle | Speedup |
|---|---|---|---|
| Small (460×690) | 3.22 ms | 2.25 ms | **1.4×** |
| Medium (800×1200) | 5.82 ms | 3.60 ms | **1.6×** |
| Large (1500×2250) | 17.3 ms | 9.79 ms | **1.8×** |

On Kindle the absolute times will be higher across the board, making the relative gain even more meaningful when downloading 20–30 covers in a single search.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tachibana-shin/rakuyomi/pull/155" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->