### PR TITLE
feat: seed default settings.json on first run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 permissions:
   contents: write
   issues: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
   pull_request:
-  workflow_dispatch:
 permissions:
   contents: write
   issues: write

--- a/backend/server/assets/default-settings.json
+++ b/backend/server/assets/default-settings.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://github.com/tachibana-shin/rakuyomi/releases/latest/download/settings.schema.json",
+  "source_lists": [
+    "https://raw.githubusercontent.com/tachibana-shin/aidoku-community-sources/gh-pages/index.min.json",
+    "https://aidoku-community.github.io/sources/index.min.json"
+  ],
+  "languages": ["en"]
+}

--- a/backend/server/assets/default-settings.json
+++ b/backend/server/assets/default-settings.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://github.com/tachibana-shin/rakuyomi/releases/latest/download/settings.schema.json",
   "source_lists": [
-    "https://raw.githubusercontent.com/tachibana-shin/aidoku-community-sources/gh-pages/index.min.json",
+    "https://tachibana-shin.github.io/aidoku-sources-next/index.min.json",
     "https://aidoku-community.github.io/sources/index.min.json"
   ],
   "languages": ["en"]

--- a/backend/server/src/main.rs
+++ b/backend/server/src/main.rs
@@ -43,6 +43,8 @@ struct Args {
 
 const SOCKET_PATH: &str = "/tmp/rakuyomi.sock";
 
+const DEFAULT_SETTINGS_JSON: &str = include_str!("../assets/default-settings.json");
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     if std::env::var("RUST_LOG").is_err() {
@@ -73,6 +75,18 @@ async fn main() -> anyhow::Result<()> {
     let database = Database::new(&database_path)
         .await
         .context("couldn't open database file")?;
+    if !settings_path.exists() {
+        info!(
+            "settings file not found at {}, creating default",
+            settings_path.display()
+        );
+        fs::write(&settings_path, DEFAULT_SETTINGS_JSON).with_context(|| {
+            format!(
+                "couldn't write default settings file at {}",
+                settings_path.display()
+            )
+        })?;
+    }
     let settings = Settings::from_file(&settings_path)
         .with_context(|| format!("couldn't read settings file at {}", settings_path.display()))?;
     let source_manager = SourceManager::from_folder(sources_path, settings.clone())

--- a/docs/src/user-guide/installation/installing-to-your-device.md
+++ b/docs/src/user-guide/installation/installing-to-your-device.md
@@ -8,20 +8,12 @@ The `settings.json` file contains basic settings that rakuyomi needs to work, in
 - **Source lists**: URLs containing information about available sources
 - **Languages**: Your preferred reading languages
 
-Here's a recommended starter configuration that you can customize or use as-is:
+A recommended starter configuration is created automatically on the first plugin start, so writing this file by hand is optional. The defaults are equivalent to the snippet below — use it as a reference if you want to customise the file before that first run.
 
 Any source that can run on [Aidoku](https://github.com/Aidoku) can also run on [rakuyomi](https://github.com/tachibana-shin/rakuyomi) (except `WebView`)
 
 ```json,downloadable:settings.json
-{
-  "$schema": "https://github.com/tachibana-shin/rakuyomi/releases/latest/download/settings.schema.json",
-  "source_lists": [
-    "https://raw.githubusercontent.com/tachibana-shin/aidoku-community-sources/gh-pages/index.min.json",
-    
-    "https://aidoku-community.github.io/sources/index.min.json"
-  ],
-  "languages": ["en"]
-}
+{{#include ../../../../backend/server/assets/default-settings.json}}
 ```
 
 ## Copying the Plugin to Your Device
@@ -39,6 +31,10 @@ Any source that can run on [Aidoku](https://github.com/Aidoku) can also run on [
 
 5. Copy the entire `rakuyomi.koplugin` folder into the `plugins` folder:
 ![plugins folder](./user-guide/installation/images/plugins-folder.png)
+
+```admonish note
+Steps 6 and 7 are only needed if you customised the snippet above. Otherwise, skip ahead — rakuyomi creates the `rakuyomi` folder and a default `settings.json` automatically on first start.
+```
 
 6. Return to the KOReader folder and create a new `rakuyomi` folder:
 ![rakuyomi folder](./user-guide/installation/images/rakuyomi-folder.png)


### PR DESCRIPTION
The server previously bailed with "couldn't read settings file" when no settings.json existed at $RAKUYOMI_HOME/settings.json. That left users with no way to bootstrap the file from inside the plugin (notably when using App Store plugin). Now the server writes a minimal default — $schema reference, two community source_lists, and languages=["en"] — when the file is missing, then loads it as usual.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tachibana-shin/rakuyomi/pull/159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
