### PR TITLE
fix(rakuyomi): prevent network ops when offline

### DIFF
--- a/frontend/rakuyomi.koplugin/ChapterListing.lua
+++ b/frontend/rakuyomi.koplugin/ChapterListing.lua
@@ -18,6 +18,7 @@ local Button = require("ui/widget/button")
 local md5 = require("ffi/sha2").md5
 local DataStorage = require("datastorage")
 local LuaSettings = require("luasettings")
+local NetworkMgr = require("ui/network/manager")
 
 local Backend = require("Backend")
 local DownloadChapter = require("jobs/DownloadChapter")
@@ -428,32 +429,34 @@ end
 function ChapterListing:fetchAndShow(manga, onReturnCallback, accept_cached_results)
   accept_cached_results = accept_cached_results or false
 
-  local cancel_id = Backend.createCancelId()
-  local refresh_chapters_response, cancelled = LoadingDialog:showAndRun(
-    _("Refreshing chapters..."),
-    function()
-      return Backend.refreshChapters(cancel_id, manga.source.id, manga.id)
-    end,
-    function()
-      Backend.cancel(cancel_id)
+  if NetworkMgr:isConnected() then
+    local cancel_id = Backend.createCancelId()
+    local refresh_chapters_response, cancelled = LoadingDialog:showAndRun(
+      _("Refreshing chapters..."),
+      function()
+        return Backend.refreshChapters(cancel_id, manga.source.id, manga.id)
+      end,
+      function()
+        Backend.cancel(cancel_id)
 
-      local cancelledMessage = InfoMessage:new {
-        text = _("Cancelled."),
-      }
-      UIManager:show(cancelledMessage)
-    end,
-    nil
-  )
+        local cancelledMessage = InfoMessage:new {
+          text = _("Cancelled."),
+        }
+        UIManager:show(cancelledMessage)
+      end,
+      nil
+    )
 
-  if cancelled then
-    return false
-  end
-
-  if refresh_chapters_response.type == 'ERROR' then
-    ErrorDialog:show(_("Refresh chapter error") .. "\n\n" .. refresh_chapters_response.message)
-
-    if not accept_cached_results then
+    if cancelled then
       return false
+    end
+
+    if refresh_chapters_response.type == 'ERROR' then
+      ErrorDialog:show(_("Refresh chapter error") .. "\n\n" .. refresh_chapters_response.message)
+
+      if not accept_cached_results then
+        return false
+      end
     end
   end
 
@@ -628,6 +631,14 @@ end
 --- @private
 function ChapterListing:refreshChapters()
   Trapper:wrap(function()
+    if not NetworkMgr:isConnected() then
+      UIManager:show(InfoMessage:new {
+        text = _("Cannot refresh chapters while offline"),
+      })
+
+      return
+    end
+
     local cancel_id = Backend.createCancelId()
     local refresh_chapters_response, cancelled = LoadingDialog:showAndRun(
       _("Refreshing chapters..."),

--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -18,6 +18,7 @@ local VerticalGroup = require("ui/widget/verticalgroup")
 local VerticalSpan = require("ui/widget/verticalspan")
 local InfoMessage = require("ui/widget/infomessage")
 local addToPlaylist = require("handlers/addToPlaylist")
+local NetworkMgr = require("ui/network/manager")
 
 local Backend = require("Backend")
 local ErrorDialog = require("ErrorDialog")
@@ -1129,6 +1130,10 @@ end
 --- @param cancel_id number
 --- @param manga Manga
 function LibraryView:_refreshManga(cancel_id, manga)
+  if not NetworkMgr:isConnected() then
+    return { type = 'ERROR', message = _("Cannot refresh while offline") }
+  end
+
   local response = Backend.refreshChapters(cancel_id, manga.source.id, manga.id)
   return response
 end
@@ -1136,6 +1141,14 @@ end
 --- @private
 --- @private
 function LibraryView:refreshAllChapters()
+  if not NetworkMgr:isConnected() then
+    UIManager:show(InfoMessage:new {
+      text = _("Cannot refresh while offline"),
+    })
+
+    return
+  end
+
   local job = RefreshLibraryChapters:new()
   if job then
     self:_runLibraryJob(
@@ -1149,6 +1162,14 @@ end
 
 --- @private
 function LibraryView:refreshAllDetails()
+  if not NetworkMgr:isConnected() then
+    UIManager:show(InfoMessage:new {
+      text = _("Cannot refresh while offline"),
+    })
+
+    return
+  end
+
   local job = RefreshLibraryDetails:new()
   if job then
     self:_runLibraryJob(

--- a/frontend/rakuyomi.koplugin/MangaInfoWidget.lua
+++ b/frontend/rakuyomi.koplugin/MangaInfoWidget.lua
@@ -25,6 +25,7 @@ local VerticalSpan = require("ui/widget/verticalspan")
 local InfoMessage = require("ui/widget/infomessage")
 local Trapper = require("ui/trapper")
 local _ = require("gettext+")
+local NetworkMgr = require("ui/network/manager")
 local Screen = Device.screen
 local T = require("ffi/util").template
 
@@ -552,6 +553,19 @@ end
 --- @param manga_id string
 --- @return SuccessfulResponse<[MManga, number]>|ErrorResponse|nil
 function MangaInfoWidget:refreshDetails(source_id, manga_id)
+  if not NetworkMgr:isConnected() then
+    local cancel_id = Backend.createCancelId()
+    local response = Backend.cachedMangaDetails(cancel_id, source_id, manga_id)
+
+    if response.type == 'ERROR' then
+      ErrorDialog:show(response.message)
+
+      return
+    end
+
+    return { type = 'SUCCESS', body = response.body }
+  end
+
   local cancel_id_1 = Backend.createCancelId()
   local cancel_id_2 = Backend.createCancelId()
 

--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -4,6 +4,7 @@ local Screen = require("device").screen
 local InfoMessage = require("ui/widget/infomessage")
 local _ = require("gettext+")
 local addToPlaylist = require("handlers/addToPlaylist")
+local NetworkMgr = require("ui/network/manager")
 
 local Backend = require("Backend")
 local ErrorDialog = require("ErrorDialog")
@@ -381,28 +382,30 @@ function MangaSearchResults:onContextMenuChoice(item)
             manga.in_library = not added
 
             if manga.in_library and Backend.getSettings().body.library_view_mode ~= 'base' then
-              local cancel_id = Backend.createCancelId()
-              local response, cancelled = LoadingDialog:showAndRun(
-                _("Refreshing details..."),
-                function() return Backend.refreshMangaDetails(cancel_id, manga.source.id, manga.id) end,
-                function()
-                  Backend.cancel(cancel_id)
+              if NetworkMgr:isConnected() then
+                local cancel_id = Backend.createCancelId()
+                local response, cancelled = LoadingDialog:showAndRun(
+                  _("Refreshing details..."),
+                  function() return Backend.refreshMangaDetails(cancel_id, manga.source.id, manga.id) end,
+                  function()
+                    Backend.cancel(cancel_id)
 
-                  local cancelledMessage = InfoMessage:new {
-                    text = _("Refresh details cancelled."),
-                  }
-                  UIManager:show(cancelledMessage)
+                    local cancelledMessage = InfoMessage:new {
+                      text = _("Refresh details cancelled."),
+                    }
+                    UIManager:show(cancelledMessage)
+                  end
+                )
+
+                if cancelled then
+                  return false
                 end
-              )
 
-              if cancelled then
-                return false
-              end
+                if response.type == 'ERROR' then
+                  ErrorDialog:show(response.message)
 
-              if response.type == 'ERROR' then
-                ErrorDialog:show(response.message)
-
-                return false
+                  return false
+                end
               end
             end
 


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Rakuyomi: skip refresh network calls when offline and use cached details
<code>🐞 Bug fix</code> <code>✨ Enhancement</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

- Check network status before refresh operations
- Show info messages when offline refresh attempted
- Attempt cached details when refreshing offline

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Gate chapter/detail refresh operations behind a connectivity check.
• Show InfoMessage feedback when a refresh is attempted offline.
• Fall back to cached manga details when refreshing while offline.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  CL["ChapterListing"] --> NM["NetworkMgr connection check"] -->|"online"| BE["Backend refresh calls"]
  CL --> NM -->|"offline"| IM["InfoMessage + return"]
  LV["LibraryView"] --> NM -->|"online"| BE
  LV --> NM -->|"offline"| IM
  MSR["MangaSearchResults"] --> NM -->|"online"| BE
  MIW["MangaInfoWidget"] --> NM -->|"offline"| BCD["Backend.cachedMangaDetails"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Centralize offline gating in Backend</b></summary>

- ➕ Eliminates duplicated NetworkMgr checks across multiple UI entrypoints
- ➕ Enforces consistent behavior/messages for all refresh operations
- ➕ Simplifies future maintenance when adding new refresh actions
- ➖ May require redefining Backend API contracts (e.g., new OFFLINE error type)
- ➖ Some UI-specific messaging/UX decisions still need to live in UI layers

</details>

<details>
<summary><b>2. Introduce a shared UI helper (e.g., runOnlineOrInform)</b></summary>

- ➕ Keeps UX decisions in UI while avoiding repeated boilerplate
- ➕ Minimal impact on Backend APIs
- ➖ Still spreads behavior across UIs (just less repetitively)
- ➖ Can become another abstraction to learn/standardize

</details>

**Recommendation:** Current approach is acceptable for a small targeted fix and improves offline usability immediately. As follow-up, consider centralizing the connectivity gate (Backend-level or shared UI helper) to avoid future drift where some refresh paths forget to check connectivity.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>MangaInfoWidget.lua</strong> <code>Use cached manga details when offline</code> <code>+14/-0</code></summary>

<br/>

>Use cached manga details when offline
>
><pre>
>• Adds an offline path in refreshDetails that fetches cached details via Backend.cachedMangaDetails and returns them as a SUCCESS result. If cached retrieval fails, shows an ErrorDialog and aborts instead of attempting network refresh.
></pre>
>
><a href='https://github.com/tachibana-shin/rakuyomi/pull/190/files#diff-44b3360fd7065502a84223f4a6ed6fa1b0bf14ffdbed506e3e2dfdc921672868'>frontend/rakuyomi.koplugin/MangaInfoWidget.lua</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Bug fix</strong> (3)</summary>

<blockquote>
<details>
<summary><strong>ChapterListing.lua</strong> <code>Skip chapter refresh when offline (and inform the user)</code> <code>+33/-22</code></summary>

<br/>

>Skip chapter refresh when offline (and inform the user)
>
><pre>
>• Adds NetworkMgr connectivity checks before running refreshChapters calls in both initial fetch-and-show flow and swipe-to-refresh. When offline, avoids network calls and shows an InfoMessage instead; when online, preserves existing cancel/error handling.
></pre>
>
><a href='https://github.com/tachibana-shin/rakuyomi/pull/190/files#diff-7c84e8a7af17a02118ec0490c8a8a2ecac50710cac5590203eb0779c4dfdff10'>frontend/rakuyomi.koplugin/ChapterListing.lua</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>LibraryView.lua</strong> <code>Guard library refresh jobs against offline state</code> <code>+21/-0</code></summary>

<br/>

>Guard library refresh jobs against offline state
>
><pre>
>• Prevents refreshAllChapters/refreshAllDetails from starting while offline and shows an InfoMessage. Also updates per-manga refresh to return an error response immediately when offline, avoiding Backend network refresh calls.
></pre>
>
><a href='https://github.com/tachibana-shin/rakuyomi/pull/190/files#diff-1bd2ac64e42c1e4bf370012f81b08aab53d26fdff8958e0c2ae29aa8feaa6912'>frontend/rakuyomi.koplugin/LibraryView.lua</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>MangaSearchResults.lua</strong> <code>Only refresh newly-added manga details when online</code> <code>+22/-19</code></summary>

<br/>

>Only refresh newly-added manga details when online
>
><pre>
>• Wraps the post-add-to-library detail refresh (refreshMangaDetails + LoadingDialog) in a NetworkMgr connectivity check. Offline mode now skips the refresh attempt, preventing errors/timeouts while keeping add/remove behavior intact.
></pre>
>
><a href='https://github.com/tachibana-shin/rakuyomi/pull/190/files#diff-e73745721d8d3e2d7b70a3cb61db0d9795dda07c49616530c1c867b40be6e702'>frontend/rakuyomi.koplugin/MangaSearchResults.lua</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refresh operations for chapters, manga details, and library are now blocked when the device is offline, preventing errors
  * Users receive clear messages when attempting to refresh while disconnected
  * The app displays cached data instead of attempting network requests when offline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->