### PR TITLE
fix(library): wrap chapter fetch in Trapper

### DIFF
--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -548,9 +548,11 @@ function LibraryView:onContextMenuChoice(item)
           self:fetchAndShow(self.current_playlist)
         end
 
-        if ChapterListing:fetchAndShow(manga, onReturnCallback, true) then
-          self:onClose()
-        end
+        Trapper:wrap(function()
+          if ChapterListing:fetchAndShow(manga, onReturnCallback, true) then
+            self:onClose()
+          end
+        end)
       end
     }})
   end


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix library context-menu chapter listing crash by wrapping fetch in Trapper
<code>🐞 Bug fix</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Wrap context-menu &quot;List chapters&quot; flow in <b><i>Trapper:wrap()</i></b> to satisfy
  <b><i>ChapterListing</i></b>/<b><i>LoadingDialog</i></b> requirements.
• Prevent crashes when fetching chapters from the library context menu.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  LV["LibraryView (context menu)"] --> TR["Trapper.wrap"] --> CL["ChapterListing.fetchAndShow"] --> LD["LoadingDialog.showAndRun"] --> BE["Backend.refreshChapters"]
  CL --> LV
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Self-wrap inside ChapterListing:fetchAndShow</b></summary>

- ➕ Eliminates repeated/forgotten `Trapper:wrap()` at call sites
- ➕ Makes the API harder to misuse; fewer crash vectors
- ➖ Risk of double-wrapping or unexpected control-flow if callers already wrap
- ➖ Changes contract/expectations for other callers; may mask improper threading/dispatch usage

</details>

<details>
<summary><b>2. Remove `LoadingDialog` Trapper assertion and handle internally</b></summary>

- ➕ Prevents hard crashes and centralizes safety in one UI utility
- ➖ Can hide programming errors and make failures harder to diagnose
- ➖ May require deeper changes to how UI tasks are scheduled/executed

</details>

**Recommendation:** This PR’s approach is appropriate for a targeted crash fix: it brings the context-menu call site into compliance with the existing documented contract (must be called within `Trapper:wrap()`). Consider a follow-up to reduce foot-guns by either self-wrapping in `ChapterListing:fetchAndShow` or providing a clearly named safe wrapper API, but those are broader behavior changes than needed for this fix.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>LibraryView.lua</strong> <code>Wrap context-menu chapter list fetch in &#x27;Trapper:wrap()&#x27;</code> <code>+5/-3</code></summary>

<br/>

>Wrap context-menu chapter list fetch in &#x27;Trapper:wrap()&#x27;
>
><pre>
>• The &quot;List chapters&quot; context-menu callback now executes &#x27;ChapterListing:fetchAndShow(...)&#x27; inside &#x27;Trapper:wrap()&#x27;. This aligns the call with &#x27;ChapterListing&#x27;/&#x27;LoadingDialog&#x27; requirements and avoids crashes when the action triggers a loading dialog / backend refresh from an unwrapped context.
></pre>
>
><a href='https://github.com/tachibana-shin/rakuyomi/pull/191/files#diff-1bd2ac64e42c1e4bf370012f81b08aab53d26fdff8958e0c2ae29aa8feaa6912'>frontend/rakuyomi.koplugin/LibraryView.lua</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>