### PR TITLE
Feat: Add Rakuyomi to the 'start with' menu

### DIFF
--- a/frontend/rakuyomi.koplugin/main.lua
+++ b/frontend/rakuyomi.koplugin/main.lua
@@ -66,6 +66,9 @@ function Rakuyomi:init()
         FileManagerMenu._rakuyomi_startwith_patched = true
         FileManagerMenu._rakuyomi_startwith_orig    = orig_fn
 
+        --- Overrides the default Start With menu table to inject a Rakuyomi option.
+        --- @param fmm_self FileManagerMenu The FileManagerMenu instance.
+        --- @return table result The modified menu table with the Rakuyomi entry added.
         FileManagerMenu.getStartWithMenuTable = function(fmm_self)
           local result = orig_fn(fmm_self)
           local sub    = result.sub_item_table

--- a/frontend/rakuyomi.koplugin/main.lua
+++ b/frontend/rakuyomi.koplugin/main.lua
@@ -1,6 +1,5 @@
 local DocumentRegistry = require("document/documentregistry")
 local InputContainer = require("ui/widget/container/inputcontainer")
-local FileManager = require("apps/filemanager/filemanager")
 local UIManager = require("ui/uimanager")
 local Dispatcher = require("dispatcher")
 local logger = require("logger")
@@ -21,8 +20,6 @@ function getBackend()
   backendInitialized, logs = Backend.initialize()
 end
 
-local _start_with_rakuyomi = nil
-
 local ok, android = pcall(require, "android")
 local Rakuyomi = InputContainer:extend({
   name = "rakuyomi"
@@ -41,15 +38,19 @@ function Rakuyomi:init()
     local orig_onShow = self.ui.onShow
     self.ui.onShow = function(fm_self, ...)
       if orig_onShow then orig_onShow(fm_self, ...) end
-      if _start_with_rakuyomi == nil then
-        _start_with_rakuyomi = G_reader_settings:readSetting("start_with") == "rakuyomi"
-      end
-      if _start_with_rakuyomi then
-        UIManager:scheduleIn(0, function()
-          getBackend()
-          LibraryView:fetchAndShow()
-          OfflineAlertDialog:showIfOffline()
-        end)
+      if not self._rakuyomi_started then
+        self._rakuyomi_started = true
+        if G_reader_settings:readSetting("start_with") == "rakuyomi" then
+          UIManager:scheduleIn(0, function()
+            getBackend()
+            if not backendInitialized then
+              self:showErrorDialog()
+              return
+            end
+            LibraryView:fetchAndShow()
+            OfflineAlertDialog:showIfOffline()
+          end)
+        end
       end
     end
 
@@ -70,20 +71,6 @@ function Rakuyomi:init()
           local sub    = result.sub_item_table
           if type(sub) ~= "table" then return result end
 
-          -- Wrap every native item's callback to clear _start_with_rakuyomi when a
-          -- native option is selected. Without this, selecting e.g. "file browser"
-          -- writes the setting directly but leaves _start_with_rakuyomi=true, causing
-          -- Rakuyomi to keep opening on boot even after the user switched away.
-          for _, item in ipairs(sub) do
-            if item.radio and type(item.callback) == "function" then
-              local orig_cb = item.callback
-              item.callback = function()
-                _start_with_rakuyomi = false
-                orig_cb()
-              end
-            end
-          end
-
           -- Add the entry only if it is not already present.
           local rakuyomi_label = _("Rakuyomi")
           local found = false
@@ -100,7 +87,6 @@ function Rakuyomi:init()
               end,
               callback = function()
                 G_reader_settings:saveSetting("start_with", "rakuyomi")
-                _start_with_rakuyomi = true
               end,
               radio = true,
             })
@@ -108,11 +94,11 @@ function Rakuyomi:init()
 
           -- Update the parent item label when Rakuyomi is the active choice.
           local orig_text_func = result.text_func
-          result.text_func = function()
+          result.text_func = function(...)
             if G_reader_settings:readSetting("start_with") == "rakuyomi" then
               return _("Start with") .. ": " .. _("Rakuyomi")
             end
-            return orig_text_func and orig_text_func() or _("Start with")
+            return orig_text_func and orig_text_func(...) or _("Start with")
           end
 
           return result

--- a/frontend/rakuyomi.koplugin/main.lua
+++ b/frontend/rakuyomi.koplugin/main.lua
@@ -1,5 +1,7 @@
 local DocumentRegistry = require("document/documentregistry")
 local InputContainer = require("ui/widget/container/inputcontainer")
+local FileManager = require("apps/filemanager/filemanager")
+local UIManager = require("ui/uimanager")
 local Dispatcher = require("dispatcher")
 local logger = require("logger")
 local _ = require("gettext+")
@@ -19,6 +21,8 @@ function getBackend()
   backendInitialized, logs = Backend.initialize()
 end
 
+local _start_with_rakuyomi = nil
+
 local ok, android = pcall(require, "android")
 local Rakuyomi = InputContainer:extend({
   name = "rakuyomi"
@@ -33,6 +37,88 @@ function Rakuyomi:init()
     MangaReader:initializeFromReaderUI(self.ui)
   else
     self.ui.menu:registerToMainMenu(self)
+
+    local orig_onShow = self.ui.onShow
+    self.ui.onShow = function(fm_self, ...)
+      if orig_onShow then orig_onShow(fm_self, ...) end
+      if _start_with_rakuyomi == nil then
+        _start_with_rakuyomi = G_reader_settings:readSetting("start_with") == "rakuyomi"
+      end
+      if _start_with_rakuyomi then
+        UIManager:scheduleIn(0, function()
+          getBackend()
+          LibraryView:fetchAndShow()
+          OfflineAlertDialog:showIfOffline()
+        end)
+      end
+    end
+
+    -- ---------------------------------------------------------------------------
+    -- "Start with Rakuyomi" menu entry
+    -- Injects the Rakuyomi radio item into KOReader's Start With submenu.
+    -- Patched once per session; a flag on the class prevents double-patching.
+    -- ---------------------------------------------------------------------------
+    local ok_fmm, FileManagerMenu = pcall(require, "apps/filemanager/filemanagermenu")
+    if ok_fmm and FileManagerMenu and not FileManagerMenu._rakuyomi_startwith_patched then
+      local orig_fn = FileManagerMenu.getStartWithMenuTable
+      if orig_fn then
+        FileManagerMenu._rakuyomi_startwith_patched = true
+        FileManagerMenu._rakuyomi_startwith_orig    = orig_fn
+
+        FileManagerMenu.getStartWithMenuTable = function(fmm_self)
+          local result = orig_fn(fmm_self)
+          local sub    = result.sub_item_table
+          if type(sub) ~= "table" then return result end
+
+          -- Wrap every native item's callback to clear _start_with_rakuyomi when a
+          -- native option is selected. Without this, selecting e.g. "file browser"
+          -- writes the setting directly but leaves _start_with_rakuyomi=true, causing
+          -- Rakuyomi to keep opening on boot even after the user switched away.
+          for _, item in ipairs(sub) do
+            if item.radio and type(item.callback) == "function" then
+              local orig_cb = item.callback
+              item.callback = function()
+                _start_with_rakuyomi = false
+                orig_cb()
+              end
+            end
+          end
+
+          -- Add the entry only if it is not already present.
+          local rakuyomi_label = _("Rakuyomi")
+          local found = false
+          for _, item in ipairs(sub) do
+            if item.text == rakuyomi_label and item.radio then found = true; break end
+          end
+          if not found then
+            table.insert(sub, math.max(1, #sub), {
+              text         = rakuyomi_label,
+              -- Read the setting directly as ground truth; fall back to the
+              -- cache only when the setting hasn't been written yet.
+              checked_func = function()
+                return G_reader_settings:readSetting("start_with") == "rakuyomi"
+              end,
+              callback = function()
+                G_reader_settings:saveSetting("start_with", "rakuyomi")
+                _start_with_rakuyomi = true
+              end,
+              radio = true,
+            })
+          end
+
+          -- Update the parent item label when Rakuyomi is the active choice.
+          local orig_text_func = result.text_func
+          result.text_func = function()
+            if G_reader_settings:readSetting("start_with") == "rakuyomi" then
+              return _("Start with") .. ": " .. _("Rakuyomi")
+            end
+            return orig_text_func and orig_text_func() or _("Start with")
+          end
+
+          return result
+        end
+      end
+    end
   end
 
   if not ok or not android then


### PR DESCRIPTION
This registers a Rakuyomi option to KOReader's 'Start With' menu. 

## Changes
No Rakuyomi code was touched, and this is purely an addition to `main.lua` taken from SimpleUI's implementation of the feature via their `sui_patches.lua`, [source](https://github.com/doctorhetfield-cmd/simpleui.koplugin/blob/main/sui_patches.lua).

## Summary
Users can optionally select Rakuymi from Koreader's 'Start With' menu to automatically launch KOReader directly into Rakuyomi's Library view. No changes to core functionality. Closes my own feature request at #188. 