### PR TITLE
perf(unix): replace fork with posix_spawn

### DIFF
--- a/frontend/rakuyomi.koplugin/platform/generic_unix_platform.lua
+++ b/frontend/rakuyomi.koplugin/platform/generic_unix_platform.lua
@@ -8,6 +8,7 @@ local util = require('frontend/util')
 ---@diagnostic disable-next-line: different-requires
 local platformUtil = require('platform/util')
 local must = platformUtil.must
+local must0 = platformUtil.must0
 local SubprocessOutputCapturer = platformUtil.SubprocessOutputCapturer
 local rapidjson = require("rapidjson")
 local execute_binary_fast = require("utils/executeBinaryFast")
@@ -23,7 +24,7 @@ ffi.cdef([[
   char *getcwd(char *buf, size_t size);
   extern char **environ;
 
-  typedef struct { char __pad[128]; } posix_spawn_file_actions_t;
+  typedef struct { uint64_t __pad[16]; } posix_spawn_file_actions_t;
   int posix_spawn(int *pid, const char *path, const posix_spawn_file_actions_t *file_actions, const void *attrp, const char *const argv[], char *const envp[]);
   int posix_spawn_file_actions_init(posix_spawn_file_actions_t *actions);
   int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *actions, int fd, int newfd);
@@ -168,17 +169,17 @@ function GenericUnixPlatform:startServer()
   end
 
   local actions = t_file_actions()
-  must("posix_spawn_file_actions_init", C.posix_spawn_file_actions_init(actions))
+  must0("posix_spawn_file_actions_init", C.posix_spawn_file_actions_init(actions))
 
   if capturer.stdout_pipe and capturer.stderr_pipe then
-    must("posix_spawn_file_actions_adddup2", C.posix_spawn_file_actions_adddup2(actions, capturer.stdout_pipe[1], 1))
-    must("posix_spawn_file_actions_adddup2", C.posix_spawn_file_actions_adddup2(actions, capturer.stderr_pipe[1], 2))
+    must0("posix_spawn_file_actions_adddup2", C.posix_spawn_file_actions_adddup2(actions, capturer.stdout_pipe[1], 1))
+    must0("posix_spawn_file_actions_adddup2", C.posix_spawn_file_actions_adddup2(actions, capturer.stderr_pipe[1], 2))
 
-    must("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[0]))
-    must("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[0]))
+    must0("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[0]))
+    must0("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[0]))
 
-    must("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[1]))
-    must("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[1]))
+    must0("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[1]))
+    must0("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[1]))
   end
 
   local old_dir = nil
@@ -200,7 +201,8 @@ function GenericUnixPlatform:startServer()
   C.posix_spawn_file_actions_destroy(actions)
 
 
-  local pid = must("posix_spawn", spawn_res == 0 and pid_ptr[0] or -1)
+  must0("posix_spawn", spawn_res)
+  local pid = pid_ptr[0]
 
   capturer:setupParentProcess()
 

--- a/frontend/rakuyomi.koplugin/platform/generic_unix_platform.lua
+++ b/frontend/rakuyomi.koplugin/platform/generic_unix_platform.lua
@@ -21,6 +21,7 @@ local SOCKET_PATH = '/tmp/rakuyomi.sock'
 
 ffi.cdef([[
   char *getcwd(char *buf, size_t size);
+  extern char **environ;
 
   typedef struct { char __pad[128]; } posix_spawn_file_actions_t;
   int posix_spawn(int *pid, const char *path, const posix_spawn_file_actions_t *file_actions, const void *attrp, const char *const argv[], char *const envp[]);
@@ -170,14 +171,14 @@ function GenericUnixPlatform:startServer()
   must("posix_spawn_file_actions_init", C.posix_spawn_file_actions_init(actions))
 
   if capturer.stdout_pipe and capturer.stderr_pipe then
-    C.posix_spawn_file_actions_adddup2(actions, capturer.stdout_pipe[1], 1)
-    C.posix_spawn_file_actions_adddup2(actions, capturer.stderr_pipe[1], 2)
+    must("posix_spawn_file_actions_adddup2", C.posix_spawn_file_actions_adddup2(actions, capturer.stdout_pipe[1], 1))
+    must("posix_spawn_file_actions_adddup2", C.posix_spawn_file_actions_adddup2(actions, capturer.stderr_pipe[1], 2))
 
-    C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[0])
-    C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[0])
+    must("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[0]))
+    must("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[0]))
 
-    C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[1])
-    C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[1])
+    must("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[1]))
+    must("posix_spawn_file_actions_addclose", C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[1]))
   end
 
   local old_dir = nil
@@ -185,12 +186,12 @@ function GenericUnixPlatform:startServer()
     local buf = ffi.new("char[4096]")
     if C.getcwd(buf, 4096) ~= nil then
       old_dir = ffi.string(buf)
+      C.chdir(SERVER_COMMAND_WORKING_DIRECTORY)
     end
-    C.chdir(SERVER_COMMAND_WORKING_DIRECTORY)
   end
 
   local pid_ptr = t_int_array()
-  local spawn_res = C.posix_spawn(pid_ptr, binaryPath, actions, nil, argv, nil)
+  local spawn_res = C.posix_spawn(pid_ptr, binaryPath, actions, nil, argv, C.environ)
 
   if old_dir ~= nil then
     C.chdir(old_dir)

--- a/frontend/rakuyomi.koplugin/platform/generic_unix_platform.lua
+++ b/frontend/rakuyomi.koplugin/platform/generic_unix_platform.lua
@@ -19,6 +19,17 @@ local REQUEST_COMMAND_OVERRIDE = os.getenv('RAKUYOMI_UDS_HTTP_REQUEST_COMMAND_OV
 
 local SOCKET_PATH = '/tmp/rakuyomi.sock'
 
+ffi.cdef([[
+  char *getcwd(char *buf, size_t size);
+
+  typedef struct { char __pad[128]; } posix_spawn_file_actions_t;
+  int posix_spawn(int *pid, const char *path, const posix_spawn_file_actions_t *file_actions, const void *attrp, const char *const argv[], char *const envp[]);
+  int posix_spawn_file_actions_init(posix_spawn_file_actions_t *actions);
+  int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *actions, int fd, int newfd);
+  int posix_spawn_file_actions_addclose(posix_spawn_file_actions_t *actions, int fd);
+  int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t *actions);
+]])
+
 ---@class UnixServer: Server
 ---@field private pid number
 ---@field private outputCapturer SubprocessOutputCapturer
@@ -122,45 +133,73 @@ end
 ---@class GenericUnixPlatform: Platform
 local GenericUnixPlatform = {}
 
+
+local t_int_array = ffi.typeof("int[1]")
+local t_file_actions = ffi.typeof("posix_spawn_file_actions_t")
+
 function GenericUnixPlatform:startServer()
-  -- setup loopback on Kobo devices (see #22)
   if Device:isKobo() then
     os.execute("ifconfig lo 127.0.0.1")
   end
 
-  local serverCommand
-  if SERVER_COMMAND_OVERRIDE ~= nil then
-    serverCommand = util.splitToArray(SERVER_COMMAND_OVERRIDE, ' ')
-  else
-    serverCommand = { Paths.getPluginDirectory() .. "/server" }
-  end
-
-  local serverCommandWithArgs = {}
-  util.arrayAppend(serverCommandWithArgs, serverCommand)
-  util.arrayAppend(serverCommandWithArgs, { Paths.getHomeDirectory() })
-
   local capturer = SubprocessOutputCapturer:new()
+  local binaryPath
+  local argv
 
-  local pid = must("fork", C.fork())
-  if pid == 0 then
-    capturer:setupChildProcess()
+  if SERVER_COMMAND_OVERRIDE ~= nil then
+    local serverCommand = util.splitToArray(SERVER_COMMAND_OVERRIDE, ' ')
+    local args = {}
+    util.arrayAppend(args, serverCommand)
+    util.arrayAppend(args, { Paths.getHomeDirectory() })
 
-    if SERVER_COMMAND_WORKING_DIRECTORY ~= nil then
-      ffi.cdef([[
-        int chdir(const char *) __attribute__((nothrow, leaf));
-      ]])
-      logger.info('changing directory to', SERVER_COMMAND_WORKING_DIRECTORY)
-      C.chdir(SERVER_COMMAND_WORKING_DIRECTORY)
+    binaryPath = args[1]
+    argv = ffi.new("const char *[?]", #args + 1)
+    for i, arg in ipairs(args) do
+      argv[i - 1] = arg
     end
-
-    local exitCode = must(
-      "execl",
-      ---@diagnostic disable-next-line: deprecated
-      C.execl(serverCommandWithArgs[1], unpack(serverCommandWithArgs, 1, #serverCommandWithArgs + 1))
-    )
-
-    logger.info("server exited with code " .. exitCode)
+    argv[#args] = nil
+  else
+    binaryPath = Paths.getPluginDirectory() .. "/server"
+    argv = ffi.new("const char *[3]")
+    argv[0] = binaryPath
+    argv[1] = Paths.getHomeDirectory()
+    argv[2] = nil
   end
+
+  local actions = t_file_actions()
+  must("posix_spawn_file_actions_init", C.posix_spawn_file_actions_init(actions))
+
+  if capturer.stdout_pipe and capturer.stderr_pipe then
+    C.posix_spawn_file_actions_adddup2(actions, capturer.stdout_pipe[1], 1)
+    C.posix_spawn_file_actions_adddup2(actions, capturer.stderr_pipe[1], 2)
+
+    C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[0])
+    C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[0])
+
+    C.posix_spawn_file_actions_addclose(actions, capturer.stdout_pipe[1])
+    C.posix_spawn_file_actions_addclose(actions, capturer.stderr_pipe[1])
+  end
+
+  local old_dir = nil
+  if SERVER_COMMAND_WORKING_DIRECTORY ~= nil then
+    local buf = ffi.new("char[4096]")
+    if C.getcwd(buf, 4096) ~= nil then
+      old_dir = ffi.string(buf)
+    end
+    C.chdir(SERVER_COMMAND_WORKING_DIRECTORY)
+  end
+
+  local pid_ptr = t_int_array()
+  local spawn_res = C.posix_spawn(pid_ptr, binaryPath, actions, nil, argv, nil)
+
+  if old_dir ~= nil then
+    C.chdir(old_dir)
+  end
+
+  C.posix_spawn_file_actions_destroy(actions)
+
+
+  local pid = must("posix_spawn", spawn_res == 0 and pid_ptr[0] or -1)
 
   capturer:setupParentProcess()
 

--- a/frontend/rakuyomi.koplugin/platform/util.lua
+++ b/frontend/rakuyomi.koplugin/platform/util.lua
@@ -14,6 +14,18 @@ function util.must(operation, return_code)
   return return_code
 end
 
+--- Like must(), but for posix_spawn APIs that return the error code directly
+--- (0 on success, positive errno on failure) instead of -1 + errno.
+---@param operation string
+---@param return_code number
+function util.must0(operation, return_code)
+  if return_code ~= 0 then
+    error("failed to " .. operation .. ": " .. ffi.string(C.strerror(return_code)))
+  end
+
+  return return_code
+end
+
 local F_SETFL = 4
 local O_NONBLOCK = 0x4
 

--- a/frontend/rakuyomi.koplugin/utils/executeBinaryFast.lua
+++ b/frontend/rakuyomi.koplugin/utils/executeBinaryFast.lua
@@ -2,81 +2,103 @@ local ffi = require("ffi")
 
 ffi.cdef [[
   int pipe(int pipefd[2]);
-  int fork(void);
-  int dup2(int oldfd, int newfd);
-  int execvp(const char *file, char *const argv[]);
   int close(int fd);
   ptrdiff_t read(int fd, void *buf, size_t count);
   int waitpid(int pid, int *wstatus, int options);
+  char *getcwd(char *buf, size_t size);
   int chdir(const char *path);
-  void _exit(int status);
+
+  typedef struct { char __pad[128]; } posix_spawn_file_actions_t;
+  int posix_spawnp(int *pid, const char *file, const posix_spawn_file_actions_t *file_actions, const void *attrp, const char *const argv[], char *const envp[]);
+  int posix_spawn_file_actions_init(posix_spawn_file_actions_t *actions);
+  int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *actions, int fd, int newfd);
+  int posix_spawn_file_actions_addclose(posix_spawn_file_actions_t *actions, int fd);
+  int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t *actions);
 ]]
 
---- Execute a binary directly using fork/execvp.
----
---- This is significantly faster and more reliable than using os.execute or KOReader's
---- subprocess mechanisms, as it avoids the overhead of starting a shell and the
---- potential security issues with raw string concatenation.
----
+local pipefd = ffi.new("int[2]")
+local pid_ptr = ffi.new("int[1]")
+local status = ffi.new("int[1]")
+local buffer = ffi.new("char[4096]")
+local path_buf = ffi.new("char[4096]")
+local argv = ffi.new("const char*[3]")
+local actions = ffi.new("posix_spawn_file_actions_t")
+
+local EINTR = 4
+
+--- Execute a binary directly using posix_spawnp (Zero-Allocation & Forkless).
 --- @param cmd_path string The path to the binary to execute.
 --- @param json_payload string The JSON payload to pass as the first argument.
 --- @param working_dir string|nil The working directory for the child process, if specified.
 --- @return string|nil The captured stdout from the binary, or nil on error.
 --- @return string|nil The error message, if an error occurred.
 local function execute_binary_fast(cmd_path, json_payload, working_dir)
-  local pipefd = ffi.new("int[2]")
   if ffi.C.pipe(pipefd) < 0 then
     return nil, "Failed to create pipe"
   end
 
-  local argv = ffi.new("const char*[3]", { cmd_path, json_payload, nil })
-
-  local pid = ffi.C.fork()
-  if pid < 0 then
+  if ffi.C.posix_spawn_file_actions_init(actions) ~= 0 then
     ffi.C.close(pipefd[0])
     ffi.C.close(pipefd[1])
-    return nil, "Failed to fork process"
-  elseif pid == 0 then
-    ffi.C.close(pipefd[0])
-    ffi.C.dup2(pipefd[1], 1)
-    ffi.C.close(pipefd[1])
+    return nil, "Failed to init file actions"
+  end
 
-    if working_dir then
-      ffi.C.chdir(working_dir)
+  ffi.C.posix_spawn_file_actions_adddup2(actions, pipefd[1], 1) -- redirect stdout vào đầu ghi của pipe
+  ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[0])   -- đóng đầu đọc ở tiến trình con
+  ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[1])   -- đóng đầu ghi gốc sau khi đã dup2
+
+  argv[0] = cmd_path
+  argv[1] = json_payload
+  argv[2] = nil
+
+  local old_dir = nil
+  if working_dir then
+    if ffi.C.getcwd(path_buf, 4096) ~= nil then
+      old_dir = ffi.string(path_buf)
     end
+    ffi.C.chdir(working_dir)
+  end
 
-    ffi.C.execvp(cmd_path, ffi.cast("char *const *", argv))
 
-    ffi.C._exit(127)
-  else
+  local spawn_res = ffi.C.posix_spawnp(pid_ptr, cmd_path, actions, nil, argv, nil)
+
+  if old_dir then
+    ffi.C.chdir(old_dir)
+  end
+
+
+  ffi.C.posix_spawn_file_actions_destroy(actions)
+
+  if spawn_res ~= 0 then
+    ffi.C.close(pipefd[0])
     ffi.C.close(pipefd[1])
+    return nil, "Failed to spawn process: " .. tostring(spawn_res)
+  end
 
-    local chunks = {}
-    local buffer = ffi.new("char[4096]")
-    local EINTR = 4
+  ffi.C.close(pipefd[1])
 
-    while true do
-      local bytes_read = ffi.C.read(pipefd[0], buffer, 4096)
-      if bytes_read > 0 then
-        table.insert(chunks, ffi.string(buffer, bytes_read))
-      elseif bytes_read == 0 then
+  local pid = pid_ptr[0]
+  local chunks = {}
+
+  while true do
+    local bytes_read = ffi.C.read(pipefd[0], buffer, 4096)
+    if bytes_read > 0 then
+      table.insert(chunks, ffi.string(buffer, bytes_read))
+    elseif bytes_read == 0 then
+      break
+    else
+      if ffi.errno() ~= EINTR then
         break
-      else
-        local err = ffi.errno()
-        if err ~= EINTR then
-          break
-        end
       end
     end
-    ffi.C.close(pipefd[0])
-
-    local status = ffi.new("int[1]")
-    while ffi.C.waitpid(pid, status, 0) < 0 do
-      if ffi.errno() ~= EINTR then break end
-    end
-
-    return table.concat(chunks)
   end
+  ffi.C.close(pipefd[0])
+
+  while ffi.C.waitpid(pid, status, 0) < 0 do
+    if ffi.errno() ~= EINTR then break end
+  end
+
+  return table.concat(chunks)
 end
 
 return execute_binary_fast

--- a/frontend/rakuyomi.koplugin/utils/executeBinaryFast.lua
+++ b/frontend/rakuyomi.koplugin/utils/executeBinaryFast.lua
@@ -7,6 +7,7 @@ ffi.cdef [[
   int waitpid(int pid, int *wstatus, int options);
   char *getcwd(char *buf, size_t size);
   int chdir(const char *path);
+  extern char **environ;
 
   typedef struct { char __pad[128]; } posix_spawn_file_actions_t;
   int posix_spawnp(int *pid, const char *file, const posix_spawn_file_actions_t *file_actions, const void *attrp, const char *const argv[], char *const envp[]);
@@ -43,9 +44,9 @@ local function execute_binary_fast(cmd_path, json_payload, working_dir)
     return nil, "Failed to init file actions"
   end
 
-  ffi.C.posix_spawn_file_actions_adddup2(actions, pipefd[1], 1) -- redirect stdout vào đầu ghi của pipe
-  ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[0])   -- đóng đầu đọc ở tiến trình con
-  ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[1])   -- đóng đầu ghi gốc sau khi đã dup2
+  ffi.C.posix_spawn_file_actions_adddup2(actions, pipefd[1], 1) -- redirect stdout to the write end of pipe
+  ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[0])   -- close read end in child process
+  ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[1])   -- close original write end after dup2
 
   argv[0] = cmd_path
   argv[1] = json_payload
@@ -55,12 +56,12 @@ local function execute_binary_fast(cmd_path, json_payload, working_dir)
   if working_dir then
     if ffi.C.getcwd(path_buf, 4096) ~= nil then
       old_dir = ffi.string(path_buf)
+      ffi.C.chdir(working_dir)
     end
-    ffi.C.chdir(working_dir)
   end
 
 
-  local spawn_res = ffi.C.posix_spawnp(pid_ptr, cmd_path, actions, nil, argv, nil)
+  local spawn_res = ffi.C.posix_spawnp(pid_ptr, cmd_path, actions, nil, argv, ffi.C.environ)
 
   if old_dir then
     ffi.C.chdir(old_dir)

--- a/frontend/rakuyomi.koplugin/utils/executeBinaryFast.lua
+++ b/frontend/rakuyomi.koplugin/utils/executeBinaryFast.lua
@@ -9,7 +9,7 @@ ffi.cdef [[
   int chdir(const char *path);
   extern char **environ;
 
-  typedef struct { char __pad[128]; } posix_spawn_file_actions_t;
+  typedef struct { uint64_t __pad[16]; } posix_spawn_file_actions_t;
   int posix_spawnp(int *pid, const char *file, const posix_spawn_file_actions_t *file_actions, const void *attrp, const char *const argv[], char *const envp[]);
   int posix_spawn_file_actions_init(posix_spawn_file_actions_t *actions);
   int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t *actions, int fd, int newfd);
@@ -44,9 +44,26 @@ local function execute_binary_fast(cmd_path, json_payload, working_dir)
     return nil, "Failed to init file actions"
   end
 
-  ffi.C.posix_spawn_file_actions_adddup2(actions, pipefd[1], 1) -- redirect stdout to the write end of pipe
-  ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[0])   -- close read end in child process
-  ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[1])   -- close original write end after dup2
+  if ffi.C.posix_spawn_file_actions_adddup2(actions, pipefd[1], 1) ~= 0 then
+    ffi.C.posix_spawn_file_actions_destroy(actions)
+    ffi.C.close(pipefd[0])
+    ffi.C.close(pipefd[1])
+    return nil, "Failed to redirect stdout in file actions"
+  end
+
+  if ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[0]) ~= 0 then
+    ffi.C.posix_spawn_file_actions_destroy(actions)
+    ffi.C.close(pipefd[0])
+    ffi.C.close(pipefd[1])
+    return nil, "Failed to close read end in file actions"
+  end
+
+  if ffi.C.posix_spawn_file_actions_addclose(actions, pipefd[1]) ~= 0 then
+    ffi.C.posix_spawn_file_actions_destroy(actions)
+    ffi.C.close(pipefd[0])
+    ffi.C.close(pipefd[1])
+    return nil, "Failed to close write end in file actions"
+  end
 
   argv[0] = cmd_path
   argv[1] = json_payload


### PR DESCRIPTION
- Avoid fork overhead on embedded devices
- Use posix_spawn for safer process execution
- Manage file actions for pipe redirection
- Implement zero-allocation runner helper