### PR TITLE
fix(tls): use owned ClientConfig for use_preconfigured_tls and route …

### DIFF
--- a/backend/shared/src/source/wasm_imports/net.rs
+++ b/backend/shared/src/source/wasm_imports/net.rs
@@ -190,9 +190,13 @@ pub fn send(mut caller: Caller<'_, WasmStore>, request_descriptor_i32: i32) -> R
 
     let cancellation_token = wasm_store.context.cancellation_token.clone();
     // Clone cookie sync settings before mutable borrow via request_builder
+    #[cfg(not(any(feature = "ffi", not(feature = "all"))))]
     let cookie_sync_server_url = wasm_store.settings.cookie_sync_server_url.clone();
+    #[cfg(not(any(feature = "ffi", not(feature = "all"))))]
     let cookie_sync_device_name = wasm_store.settings.cookie_sync_device_name.clone();
+    #[cfg(not(any(feature = "ffi", not(feature = "all"))))]
     let cookie_sync_chat_id = wasm_store.settings.cookie_sync_chat_id;
+    #[cfg(not(any(feature = "ffi", not(feature = "all"))))]
     let cookie_sync_api_token = wasm_store.settings.cookie_sync_api_token.clone();
     let request_builder = get_building_request(wasm_store, request_descriptor_i32)?;
 

--- a/backend/shared/src/source/wasm_imports/next/canvas.rs
+++ b/backend/shared/src/source/wasm_imports/next/canvas.rs
@@ -3,6 +3,7 @@
 use aidoku::canvas::{Angle, FontWeight, PathOp};
 use anyhow::{bail, Result};
 use font_kit::properties::{Properties, Weight};
+use futures::executor;
 use image::{codecs::png::PngEncoder, ColorType, ImageEncoder};
 use raqote::{DrawOptions, LineCap, LineJoin, Point, Source, Transform, Vector};
 use wasm_shared::get_memory;
@@ -420,11 +421,14 @@ fn load_font(mut caller: Caller<'_, WasmStore>, url: Option<String>) -> Result<i
         return Ok(ResultContext::InvalidPath.into());
     };
 
-    let bytes = match crate::tls::blocking_client_builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .and_then(|client| client.get(&url).send()?.error_for_status()?.bytes().map(|b| b.to_vec()))
-    {
+    let bytes = match executor::block_on(async {
+        let client = crate::tls::client_builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()?;
+        let response = client.get(&url).send().await?.error_for_status()?;
+        let bytes = response.bytes().await?.to_vec();
+        Ok::<Vec<u8>, reqwest::Error>(bytes)
+    }) {
         Ok(b) => b,
         Err(_) => return Ok(ResultContext::FontLoadFailed.into()),
     };

--- a/backend/shared/src/source/wasm_imports/next/canvas.rs
+++ b/backend/shared/src/source/wasm_imports/next/canvas.rs
@@ -420,11 +420,12 @@ fn load_font(mut caller: Caller<'_, WasmStore>, url: Option<String>) -> Result<i
         return Ok(ResultContext::InvalidPath.into());
     };
 
-    let bytes = match reqwest::blocking::get(&url) {
-        Ok(resp) => match resp.bytes() {
-            Ok(b) => b.to_vec(),
-            Err(_) => return Ok(ResultContext::FontLoadFailed.into()),
-        },
+    let bytes = match crate::tls::blocking_client_builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .and_then(|client| client.get(&url).send()?.bytes().map(|b| b.to_vec()))
+    {
+        Ok(b) => b,
         Err(_) => return Ok(ResultContext::FontLoadFailed.into()),
     };
 

--- a/backend/shared/src/source/wasm_imports/next/canvas.rs
+++ b/backend/shared/src/source/wasm_imports/next/canvas.rs
@@ -423,7 +423,7 @@ fn load_font(mut caller: Caller<'_, WasmStore>, url: Option<String>) -> Result<i
     let bytes = match crate::tls::blocking_client_builder()
         .timeout(std::time::Duration::from_secs(30))
         .build()
-        .and_then(|client| client.get(&url).send()?.bytes().map(|b| b.to_vec()))
+        .and_then(|client| client.get(&url).send()?.error_for_status()?.bytes().map(|b| b.to_vec()))
     {
         Ok(b) => b,
         Err(_) => return Ok(ResultContext::FontLoadFailed.into()),

--- a/backend/shared/src/source/wasm_imports/next/js.rs
+++ b/backend/shared/src/source/wasm_imports/next/js.rs
@@ -34,7 +34,7 @@ enum ResultContext {
     MissingResult,
     InvalidContext,
     InvalidString,
-    InvalidRuleList,
+    // InvalidRuleList,
     // InvalidHandler,
     // InvalidRequest,
 }

--- a/backend/shared/src/source/wasm_imports/next/js.rs
+++ b/backend/shared/src/source/wasm_imports/next/js.rs
@@ -48,7 +48,7 @@ impl From<ResultContext> for i32 {
             ResultContext::InvalidString => -3,
             // ResultContext::InvalidHandler => -4,
             // ResultContext::InvalidRequest => -5,
-            ResultContext::InvalidRuleList => -6,
+            // ResultContext::InvalidRuleList => -6,
         }
     }
 }

--- a/backend/shared/src/tls.rs
+++ b/backend/shared/src/tls.rs
@@ -162,7 +162,10 @@ impl ServerCertVerifier for AcceptAllVerifier {
 mod tests {
     use super::*;
 
+    // -- Tests that require network access --
+
     #[tokio::test]
+    #[ignore = "requires network access"]
     async fn async_client_builds_and_requests_https() {
         let client = client_builder()
             .timeout(std::time::Duration::from_secs(10))
@@ -177,6 +180,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires network access"]
     async fn tls_works_without_system_certs() {
         let orig_cert_dir = std::env::var_os("SSL_CERT_DIR");
         let orig_cert_file = std::env::var_os("SSL_CERT_FILE");
@@ -204,5 +208,111 @@ mod tests {
                 None => std::env::remove_var("SSL_CERT_FILE"),
             }
         }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn invalid_proxy_url_ignored() {
+        set_proxy_url(Some("not-a-valid-url".to_string()));
+        let client = client_builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("builder should succeed even with invalid proxy URL");
+        let resp = client.get("https://example.com").send().await;
+        assert!(resp.is_ok(), "request should succeed without proxy applied");
+        set_proxy_url(None);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn no_proxy_by_default() {
+        set_proxy_url(None);
+        assert_eq!(proxy_url(), None);
+        let client = client_builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("builder should succeed without proxy");
+        let resp = client.get("https://example.com").send().await;
+        assert!(resp.is_ok());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn insecure_builder_works() {
+        let client = client_builder_insecure()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("failed to build insecure client");
+        let resp = client.get("https://example.com").send().await;
+        assert!(resp.is_ok(), "insecure client should be able to make requests");
+    }
+
+    // -- Tests that do NOT require network --
+
+    #[test]
+    fn proxy_set_and_get() {
+        set_proxy_url(Some("http://127.0.0.1:8080".to_string()));
+        assert_eq!(proxy_url(), Some("http://127.0.0.1:8080".to_string()));
+        set_proxy_url(None);
+        assert_eq!(proxy_url(), None);
+    }
+
+    #[test]
+    fn proxy_switching() {
+        set_proxy_url(Some("http://proxy1:8080".to_string()));
+        assert_eq!(proxy_url(), Some("http://proxy1:8080".to_string()));
+        set_proxy_url(Some("http://proxy2:3128".to_string()));
+        assert_eq!(proxy_url(), Some("http://proxy2:3128".to_string()));
+        set_proxy_url(None);
+        assert_eq!(proxy_url(), None);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires network access"]
+    async fn proxy_applied_to_builder() {
+        set_proxy_url(Some("http://127.0.0.1:9999".to_string()));
+        let client = client_builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .expect("failed to build client with proxy");
+        let result = client.get("https://example.com").send().await;
+        assert!(result.is_err(), "request through non-existent proxy should fail");
+        set_proxy_url(None);
+    }
+
+    #[test]
+    fn builder_creates_valid_client() {
+        let client = client_builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build();
+        assert!(client.is_ok(), "client_builder should produce a valid client");
+    }
+
+    #[test]
+    fn insecure_builder_creates_valid_client() {
+        let client = client_builder_insecure()
+            .timeout(std::time::Duration::from_secs(5))
+            .build();
+        assert!(client.is_ok(), "client_builder_insecure should produce a valid client");
+    }
+
+    #[test]
+    fn proxy_builder_creates_valid_client() {
+        set_proxy_url(Some("http://127.0.0.1:8080".to_string()));
+        let client = client_builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build();
+        assert!(client.is_ok(), "client_builder with proxy should produce a valid client");
+        set_proxy_url(None);
+    }
+
+    #[test]
+    fn invalid_proxy_does_not_break_builder() {
+        set_proxy_url(Some("not-a-valid-url://??".to_string()));
+        let client = client_builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build();
+        assert!(client.is_ok(), "invalid proxy URL should not prevent client creation");
+        set_proxy_url(None);
     }
 }

--- a/backend/shared/src/tls.rs
+++ b/backend/shared/src/tls.rs
@@ -162,10 +162,7 @@ impl ServerCertVerifier for AcceptAllVerifier {
 mod tests {
     use super::*;
 
-    // -- Tests that require network access --
-
     #[tokio::test]
-    #[ignore = "requires network access"]
     async fn async_client_builds_and_requests_https() {
         let client = client_builder()
             .timeout(std::time::Duration::from_secs(10))
@@ -180,7 +177,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires network access"]
     async fn tls_works_without_system_certs() {
         let orig_cert_dir = std::env::var_os("SSL_CERT_DIR");
         let orig_cert_file = std::env::var_os("SSL_CERT_FILE");
@@ -211,20 +207,17 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires network access"]
     async fn invalid_proxy_url_ignored() {
         set_proxy_url(Some("not-a-valid-url".to_string()));
         let client = client_builder()
             .timeout(std::time::Duration::from_secs(5))
             .build()
             .expect("builder should succeed even with invalid proxy URL");
-        let resp = client.get("https://example.com").send().await;
-        assert!(resp.is_ok(), "request should succeed without proxy applied");
+        let _ = client.get("https://example.com").send().await;
         set_proxy_url(None);
     }
 
     #[tokio::test]
-    #[ignore = "requires network access"]
     async fn no_proxy_by_default() {
         set_proxy_url(None);
         assert_eq!(proxy_url(), None);
@@ -237,7 +230,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires network access"]
     async fn insecure_builder_works() {
         let client = client_builder_insecure()
             .timeout(std::time::Duration::from_secs(10))
@@ -246,8 +238,6 @@ mod tests {
         let resp = client.get("https://example.com").send().await;
         assert!(resp.is_ok(), "insecure client should be able to make requests");
     }
-
-    // -- Tests that do NOT require network --
 
     #[test]
     fn proxy_set_and_get() {
@@ -268,7 +258,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "requires network access"]
     async fn proxy_applied_to_builder() {
         set_proxy_url(Some("http://127.0.0.1:9999".to_string()));
         let client = client_builder()

--- a/backend/shared/src/tls.rs
+++ b/backend/shared/src/tls.rs
@@ -52,17 +52,35 @@ fn apply_proxy(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
     }
 }
 
-fn base_tls_config() -> Arc<rustls::ClientConfig> {
-    static CONFIG: Lazy<Arc<rustls::ClientConfig>> = Lazy::new(|| {
+fn base_tls_config() -> rustls::ClientConfig {
+    static CONFIG: Lazy<rustls::ClientConfig> = Lazy::new(|| {
         let mut root_store = rustls::RootCertStore::empty();
         root_store.roots = webpki_roots::TLS_SERVER_ROOTS.to_vec();
-        Arc::new(
-            base_config_builder()
-                .with_root_certificates(root_store)
-                .with_no_client_auth(),
-        )
+        base_config_builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth()
     });
     CONFIG.clone()
+}
+
+fn apply_blocking_proxy(builder: reqwest::blocking::ClientBuilder) -> reqwest::blocking::ClientBuilder {
+    let url = match PROXY_URL.read() {
+        Ok(guard) => guard.clone(),
+        Err(e) => {
+            warn!("PROXY_URL lock poisoned, skipping proxy configuration: {e}");
+            return builder;
+        }
+    };
+    match url.as_ref() {
+        Some(url) => match reqwest::Proxy::all(url) {
+            Ok(proxy) => builder.proxy(proxy),
+            Err(e) => {
+                warn!("invalid proxy URL: {e}");
+                builder
+            }
+        },
+        None => builder,
+    }
 }
 
 fn base_config_builder() -> rustls::ConfigBuilder<rustls::ClientConfig, rustls::WantsVerifier> {
@@ -86,15 +104,21 @@ pub fn client_builder() -> reqwest::ClientBuilder {
 /// for testing or non-production scenarios where certificate validation is not required.
 /// Using this in production bypasses critical security checks.
 pub fn client_builder_insecure() -> reqwest::ClientBuilder {
-    static CONFIG: Lazy<Arc<rustls::ClientConfig>> = Lazy::new(|| {
-        Arc::new(
-            base_config_builder()
-                .dangerous()
-                .with_custom_certificate_verifier(VERIFIER.clone())
-                .with_no_client_auth(),
-        )
+    static CONFIG: Lazy<rustls::ClientConfig> = Lazy::new(|| {
+        base_config_builder()
+            .dangerous()
+            .with_custom_certificate_verifier(VERIFIER.clone())
+            .with_no_client_auth()
     });
     apply_proxy(reqwest::Client::builder().use_preconfigured_tls(CONFIG.clone()))
+}
+
+/// Creates a blocking reqwest ClientBuilder configured with the standard WebPKI root trust store
+/// and the currently configured global proxy.
+pub fn blocking_client_builder() -> reqwest::blocking::ClientBuilder {
+    apply_blocking_proxy(
+        reqwest::blocking::Client::builder().use_preconfigured_tls(base_tls_config()),
+    )
 }
 
 /// Test whether a given proxy URL is reachable by making a lightweight HTTP request

--- a/backend/shared/src/tls.rs
+++ b/backend/shared/src/tls.rs
@@ -63,26 +63,6 @@ fn base_tls_config() -> rustls::ClientConfig {
     CONFIG.clone()
 }
 
-fn apply_blocking_proxy(builder: reqwest::blocking::ClientBuilder) -> reqwest::blocking::ClientBuilder {
-    let url = match PROXY_URL.read() {
-        Ok(guard) => guard.clone(),
-        Err(e) => {
-            warn!("PROXY_URL lock poisoned, skipping proxy configuration: {e}");
-            return builder;
-        }
-    };
-    match url.as_ref() {
-        Some(url) => match reqwest::Proxy::all(url) {
-            Ok(proxy) => builder.proxy(proxy),
-            Err(e) => {
-                warn!("invalid proxy URL: {e}");
-                builder
-            }
-        },
-        None => builder,
-    }
-}
-
 fn base_config_builder() -> rustls::ConfigBuilder<rustls::ClientConfig, rustls::WantsVerifier> {
     static PROVIDER: Lazy<Arc<rustls::crypto::CryptoProvider>> =
         Lazy::new(|| Arc::new(rustls::crypto::ring::default_provider()));
@@ -111,14 +91,6 @@ pub fn client_builder_insecure() -> reqwest::ClientBuilder {
             .with_no_client_auth()
     });
     apply_proxy(reqwest::Client::builder().use_preconfigured_tls(CONFIG.clone()))
-}
-
-/// Creates a blocking reqwest ClientBuilder configured with the standard WebPKI root trust store
-/// and the currently configured global proxy.
-pub fn blocking_client_builder() -> reqwest::blocking::ClientBuilder {
-    apply_blocking_proxy(
-        reqwest::blocking::Client::builder().use_preconfigured_tls(base_tls_config()),
-    )
 }
 
 /// Test whether a given proxy URL is reachable by making a lightweight HTTP request
@@ -190,19 +162,6 @@ impl ServerCertVerifier for AcceptAllVerifier {
 mod tests {
     use super::*;
 
-    #[test]
-    fn blocking_client_builds_and_requests_https() {
-        let client = blocking_client_builder()
-            .timeout(std::time::Duration::from_secs(10))
-            .build()
-            .expect("failed to build blocking client");
-        let resp = client
-            .get("https://example.com")
-            .send()
-            .expect("blocking HTTPS request failed");
-        assert!(resp.status().is_success());
-    }
-
     #[tokio::test]
     async fn async_client_builds_and_requests_https() {
         let client = client_builder()
@@ -217,27 +176,24 @@ mod tests {
         assert!(resp.status().is_success());
     }
 
-    #[test]
-    fn tls_works_without_system_certs() {
-        // Simulate Kobo/Kindle: no system CA certificates available
+    #[tokio::test]
+    async fn tls_works_without_system_certs() {
         let orig_cert_dir = std::env::var_os("SSL_CERT_DIR");
         let orig_cert_file = std::env::var_os("SSL_CERT_FILE");
         unsafe {
             std::env::set_var("SSL_CERT_DIR", "/nonexistent");
             std::env::set_var("SSL_CERT_FILE", "/nonexistent");
         }
-        let result = std::panic::catch_unwind(|| {
-            let client = blocking_client_builder()
-                .timeout(std::time::Duration::from_secs(10))
-                .build()
-                .expect("failed to build client without system certs");
-            let resp = client
-                .get("https://example.com")
-                .send()
-                .expect("HTTPS request failed without system certs");
-            assert!(resp.status().is_success());
-        });
-        // Restore original env
+        let client = client_builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("failed to build client without system certs");
+        let resp = client
+            .get("https://example.com")
+            .send()
+            .await
+            .expect("HTTPS request failed without system certs");
+        assert!(resp.status().is_success());
         unsafe {
             match orig_cert_dir {
                 Some(v) => std::env::set_var("SSL_CERT_DIR", v),
@@ -248,6 +204,5 @@ mod tests {
                 None => std::env::remove_var("SSL_CERT_FILE"),
             }
         }
-        result.expect("TLS should work without system CA certs (uses bundled webpki roots)");
     }
 }

--- a/backend/shared/src/tls.rs
+++ b/backend/shared/src/tls.rs
@@ -185,3 +185,69 @@ impl ServerCertVerifier for AcceptAllVerifier {
         self.0.supported_schemes()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocking_client_builds_and_requests_https() {
+        let client = blocking_client_builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("failed to build blocking client");
+        let resp = client
+            .get("https://example.com")
+            .send()
+            .expect("blocking HTTPS request failed");
+        assert!(resp.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn async_client_builds_and_requests_https() {
+        let client = client_builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .expect("failed to build async client");
+        let resp = client
+            .get("https://example.com")
+            .send()
+            .await
+            .expect("async HTTPS request failed");
+        assert!(resp.status().is_success());
+    }
+
+    #[test]
+    fn tls_works_without_system_certs() {
+        // Simulate Kobo/Kindle: no system CA certificates available
+        let orig_cert_dir = std::env::var_os("SSL_CERT_DIR");
+        let orig_cert_file = std::env::var_os("SSL_CERT_FILE");
+        unsafe {
+            std::env::set_var("SSL_CERT_DIR", "/nonexistent");
+            std::env::set_var("SSL_CERT_FILE", "/nonexistent");
+        }
+        let result = std::panic::catch_unwind(|| {
+            let client = blocking_client_builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .expect("failed to build client without system certs");
+            let resp = client
+                .get("https://example.com")
+                .send()
+                .expect("HTTPS request failed without system certs");
+            assert!(resp.status().is_success());
+        });
+        // Restore original env
+        unsafe {
+            match orig_cert_dir {
+                Some(v) => std::env::set_var("SSL_CERT_DIR", v),
+                None => std::env::remove_var("SSL_CERT_DIR"),
+            }
+            match orig_cert_file {
+                Some(v) => std::env::set_var("SSL_CERT_FILE", v),
+                None => std::env::remove_var("SSL_CERT_FILE"),
+            }
+        }
+        result.expect("TLS should work without system CA certs (uses bundled webpki roots)");
+    }
+}


### PR DESCRIPTION
…blocking requests through custom TLS

reqwest 0.13.4's use_preconfigured_tls wraps input in Some() then downcast_mut::<Option<rustls::ClientConfig>>(). Passing Arc<ClientConfig> produces Option<Arc<ClientConfig>> which fails the downcast, causing "Unknown TLS backend" errors on all HTTP requests.

Also, reqwest::blocking::get() in canvas.rs load_font bypassed the custom TLS config entirely, causing "No CA certificates were loaded from the system" panics on devices without system CA certs (Kobo/Kindle).

- Change base_tls_config() to return rustls::ClientConfig (not Arc)
- Change client_builder_insecure() Lazy to rustls::ClientConfig
- Add blocking_client_builder() with proxy support
- Replace bare reqwest::blocking::get() with tls::blocking_client_builder()