### PR TITLE
Add sort-based quick search (Popular/Views/Rating/Bookmarks)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: "lts/*"
 
@@ -155,7 +155,7 @@ jobs:
       with:
         persist-credentials: true
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: "lts/*"
     - name: Install dependencies

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -344,10 +344,11 @@ async fn get_mangas(
 
     if settings.search_view_mode != shared::settings::SearchViewMode::Base {
         for manga in mangas.iter_mut() {
-            if manga.information.cover_url.is_some() {
-                manga.information.cover_url = chapter_storage
-                    .poster_exists(&manga.information.id)
-                    .and_then(|path| path_to_file_url(&path));
+            if let Some(local_url) = chapter_storage
+                .poster_exists(&manga.information.id)
+                .and_then(|path| path_to_file_url(&path))
+            {
+                manga.information.cover_url = Some(local_url);
             }
         }
     }

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -290,6 +290,7 @@ struct GetMangasQuery {
     exclude: Option<String>,
     q: String,
     page: Option<i32>,
+    sort: Option<String>,
 }
 
 async fn get_mangas(
@@ -306,6 +307,7 @@ async fn get_mangas(
         exclude,
         q,
         page,
+        sort,
     }): Query<GetMangasQuery>,
 ) -> Result<Json<(Vec<Manga>, Vec<usecases::search_mangas::SearchError>, bool)>, AppError> {
     let chapter_storage = chapter_storage.lock().await;
@@ -320,6 +322,7 @@ async fn get_mangas(
     });
 
     let page = page.unwrap_or(1).max(1);
+    let sort_bucket = sort.and_then(|s| s.parse::<shared::source::SortBucket>().ok());
 
     let (mut mangas, errors, has_next_page) =
         cancel_after(&token.0, Duration::from_secs(59), |token| {
@@ -333,6 +336,7 @@ async fn get_mangas(
                 &exclude,
                 page,
                 30,
+                sort_bucket,
             )
         })
         .await

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -404,13 +404,16 @@ async fn add_manga_to_library(
         settings,
         ..
     }): StateExtractor<State>,
+    SourceExtractor(source): SourceExtractor,
     Path(params): Path<MangaChaptersPathParams>,
 ) -> Result<Json<()>, AppError> {
     let manga_id = MangaId::from(params);
 
-    let settings = settings.lock().await;
+    let token = tokio_util::sync::CancellationToken::new();
 
-    usecases::add_manga_to_library(&database, manga_id).await?;
+    usecases::add_manga_to_library(&token, &database, &source, manga_id, 30).await?;
+
+    let settings = settings.lock().await;
 
     if settings.enabled_cron_check_mangas_update {
         let db = database.clone();

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -322,7 +322,7 @@ async fn get_mangas(
     });
 
     let page = page.unwrap_or(1).max(1);
-    let sort_bucket = sort.and_then(|s| s.parse::<shared::source::SortBucket>().ok());
+    let sort_bucket = sort.and_then(|s| shared::source::SortBucket::try_from(s.as_str()).ok());
 
     let (mut mangas, errors, has_next_page) =
         cancel_after(&token.0, Duration::from_secs(59), |token| {

--- a/backend/server/src/model.rs
+++ b/backend/server/src/model.rs
@@ -13,6 +13,7 @@ pub struct SourceInformation {
     id: String,
     name: String,
     version: usize,
+    supported_sort_buckets: Vec<String>,
     source_of_source: Option<String>,
 }
 
@@ -22,6 +23,7 @@ impl From<DomainSourceInformation> for SourceInformation {
             id: value.id.value().clone(),
             name: value.name,
             version: value.version,
+            supported_sort_buckets: value.supported_sort_buckets,
             source_of_source: value.source_of_source,
         }
     }

--- a/backend/shared/benches/search_mangas_benchmark.rs
+++ b/backend/shared/benches/search_mangas_benchmark.rs
@@ -47,6 +47,7 @@ pub fn search_mangas_benchmark(c: &mut Criterion) {
                 &None,
                 1,
                 60,
+                None,
             )
             .await
             .unwrap();

--- a/backend/shared/src/model.rs
+++ b/backend/shared/src/model.rs
@@ -95,6 +95,7 @@ pub struct SourceInformation {
     pub id: SourceId,
     pub name: String,
     pub version: usize,
+    pub supported_sort_buckets: Vec<String>,
 
     // source of source
     #[serde(skip)]
@@ -281,6 +282,7 @@ impl From<SourceManifest> for SourceInformation {
             id: SourceId::new(value.info.id),
             name: value.info.name,
             version: value.info.version,
+            supported_sort_buckets: vec![],
             source_of_source: value.source_of_source,
         }
     }

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     fs,
     io::Read,
-    path::Path,
+    path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
 use tokio_util::bytes::Bytes;
@@ -362,7 +362,8 @@ pub struct BlockingSource {
     pub setting_definitions: Vec<SettingDefinition>,
     pub next_sdk: bool,
     pub features: SourceFeatures,
-    pub sort_filter: Option<SortFilterDef>,
+    pub path: PathBuf,
+    pub sort_buckets_cache: Vec<SortBucket>,
 }
 
 #[cfg(feature = "all")]
@@ -374,7 +375,8 @@ struct BlockingSource {
     setting_definitions: Vec<SettingDefinition>,
     pub next_sdk: bool,
     pub features: SourceFeatures,
-    pub sort_filter: Option<SortFilterDef>,
+    pub path: PathBuf,
+    pub sort_buckets_cache: Vec<SortBucket>,
 }
 
 impl BlockingSource {
@@ -549,15 +551,9 @@ impl BlockingSource {
             );
         }
 
-        let sort_filter = archive
-            .by_name("Payload/filters.json")
-            .ok()
-            .and_then(|file| {
-                serde_json::from_reader::<_, Vec<SortFilterDef>>(file)
-                    .map_err(|err| eprintln!("read file filters.json failed {}", err))
-                    .ok()
-            })
-            .and_then(|filters| filters.into_iter().find(|f| f.filter_type == "sort"));
+        let sort_buckets_cache = Self::read_sort_filter_from_archive(&mut archive)
+            .map(|filter| buckets_from_filter(&filter))
+            .unwrap_or_default();
 
         Ok(Self {
             id,
@@ -567,7 +563,8 @@ impl BlockingSource {
             next_sdk: aidoku_sdk_next,
             setting_definitions,
             features,
-            sort_filter,
+            path: path.to_path_buf(),
+            sort_buckets_cache,
         })
     }
 
@@ -652,8 +649,32 @@ impl BlockingSource {
         .map(|mangas| (mangas, false))
     }
 
+    fn read_sort_filter_from_archive<R: Read + std::io::Seek>(
+        archive: &mut ZipArchive<R>,
+    ) -> Option<SortFilterDef> {
+        let file = archive.by_name("Payload/filters.json").ok()?;
+        let filters: Vec<SortFilterDef> = serde_json::from_reader(file)
+            .map_err(|err| eprintln!("read file filters.json failed {}", err))
+            .ok()?;
+        filters.into_iter().find(|f| f.filter_type == "sort")
+    }
+
+    fn read_sort_filter_from_disk(path: &Path) -> Option<SortFilterDef> {
+        let file = fs::File::open(path)
+            .map_err(|err| eprintln!("open source file failed {}", err))
+            .ok()?;
+        let mut archive = ZipArchive::new(file)
+            .map_err(|err| eprintln!("open source archive failed {}", err))
+            .ok()?;
+        Self::read_sort_filter_from_archive(&mut archive)
+    }
+
     pub fn resolve_sort_filter(&self, bucket: SortBucket) -> Option<FilterValue> {
-        let filter = self.sort_filter.as_ref()?;
+        if !self.sort_buckets_cache.contains(&bucket) {
+            return None;
+        }
+
+        let filter = Self::read_sort_filter_from_disk(&self.path)?;
 
         let matches: Vec<usize> = filter
             .options
@@ -675,17 +696,7 @@ impl BlockingSource {
     }
 
     pub fn supported_sort_buckets(&self) -> Vec<SortBucket> {
-        [
-            SortBucket::Popular,
-            SortBucket::Views,
-            SortBucket::Rating,
-            SortBucket::Bookmarks,
-            SortBucket::Updated,
-            SortBucket::Added,
-        ]
-        .into_iter()
-        .filter(|&bucket| self.resolve_sort_filter(bucket).is_some())
-        .collect()
+        self.sort_buckets_cache.clone()
     }
 
     pub fn search_mangas_sorted(
@@ -1685,4 +1696,25 @@ fn match_sort_bucket(label: &str) -> Option<SortBucket> {
     }
 
     None
+}
+
+fn buckets_from_filter(filter: &SortFilterDef) -> Vec<SortBucket> {
+    [
+        SortBucket::Popular,
+        SortBucket::Views,
+        SortBucket::Rating,
+        SortBucket::Bookmarks,
+        SortBucket::Updated,
+        SortBucket::Added,
+    ]
+    .into_iter()
+    .filter(|&bucket| {
+        filter
+            .options
+            .iter()
+            .filter(|label| match_sort_bucket(label) == Some(bucket))
+            .count()
+            == 1
+    })
+    .collect()
 }

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -651,15 +651,15 @@ impl BlockingSource {
 
     fn read_sort_filter_from_archive<R: Read + std::io::Seek>(
         archive: &mut ZipArchive<R>,
-    ) -> Option<SortFilterDef> {
+    ) -> Option<SortFilterDefinition> {
         let file = archive.by_name("Payload/filters.json").ok()?;
-        let filters: Vec<SortFilterDef> = serde_json::from_reader(file)
+        let filters: Vec<SortFilterDefinition> = serde_json::from_reader(file)
             .map_err(|err| eprintln!("read file filters.json failed {}", err))
             .ok()?;
         filters.into_iter().find(|f| f.filter_type == "sort")
     }
 
-    fn read_sort_filter_from_disk(path: &Path) -> Option<SortFilterDef> {
+    fn read_sort_filter_from_disk(path: &Path) -> Option<SortFilterDefinition> {
         let file = fs::File::open(path)
             .map_err(|err| eprintln!("open source file failed {}", err))
             .ok()?;
@@ -1594,23 +1594,24 @@ pub enum SortBucket {
     Added,
 }
 
-impl std::str::FromStr for SortBucket {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, ()> {
-        match s {
+impl TryFrom<&str> for SortBucket {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &str) -> anyhow::Result<Self> {
+        match value {
             "popular" => Ok(SortBucket::Popular),
             "views" => Ok(SortBucket::Views),
             "rating" => Ok(SortBucket::Rating),
             "bookmarks" => Ok(SortBucket::Bookmarks),
             "updated" => Ok(SortBucket::Updated),
             "added" => Ok(SortBucket::Added),
-            _ => Err(()),
+            other => Err(anyhow::anyhow!("unsupported sort bucket: {other}")),
         }
     }
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct SortFilterDef {
+pub struct SortFilterDefinition {
     #[serde(rename = "type")]
     pub filter_type: String,
     pub id: String,
@@ -1698,7 +1699,7 @@ fn match_sort_bucket(label: &str) -> Option<SortBucket> {
     None
 }
 
-fn buckets_from_filter(filter: &SortFilterDef) -> Vec<SortBucket> {
+fn buckets_from_filter(filter: &SortFilterDefinition) -> Vec<SortBucket> {
     [
         SortBucket::Popular,
         SortBucket::Views,

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -1597,7 +1597,7 @@ const NON_SORT_SIGNAL: &[&str] = &[
 ];
 
 fn strip_accents(s: &str) -> String {
-    s.nfkd().filter(|c| !c.is_mark_nonspacing()).collect()
+    s.nfkd().filter(char::is_ascii).collect()
 }
 
 fn match_sort_bucket(label: &str) -> Option<SortBucket> {

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -191,6 +191,19 @@ impl Source {
     );
 
     wrap_blocking_source_fn!(
+        search_mangas_sorted,
+        Result<(Vec<Manga>, bool)>,
+        cancellation_token: CancellationToken,
+        query: String,
+        page: i32,
+        sort_bucket: Option<SortBucket>
+    );
+
+    pub fn supported_sort_buckets(&self) -> Vec<SortBucket> {
+        self.0.lock().unwrap().supported_sort_buckets()
+    }
+    
+    wrap_blocking_source_fn!(
         get_manga_details,
         Result<Manga>,
         cancellation_token: CancellationToken,

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -671,14 +671,17 @@ impl BlockingSource {
     }
 
     pub fn supported_sort_buckets(&self) -> Vec<SortBucket> {
-        let Some(filter) = &self.sort_filter else {
-            return vec![];
-        };
-        filter
-            .options
-            .iter()
-            .filter_map(|label| match_sort_bucket(label))
-            .collect()
+        [
+            SortBucket::Popular,
+            SortBucket::Views,
+            SortBucket::Rating,
+            SortBucket::Bookmarks,
+            SortBucket::Updated,
+            SortBucket::Added,
+        ]
+        .into_iter()
+        .filter(|&bucket| self.resolve_sort_filter(bucket).is_some())
+        .collect()
     }
 
     pub fn search_mangas_sorted(
@@ -1604,7 +1607,7 @@ const NON_SORT_SIGNAL: &[&str] = &[
     "week",
     "month",
     "year",
-    "best", "match", "name", "old", "publish", "title",
+    "best", "match", "name", "old", "publish", "title", "review", "revis",
     "tang", // vi. "increasing" (excluded so "giảm"/decreasing wins — highest count first)
     "meno", // it. "less"
 ];
@@ -1632,7 +1635,7 @@ fn match_sort_bucket(label: &str) -> Option<SortBucket> {
     }
 
     if stripped.contains("book") // "bookmark"
-        || stripped.contains("sub") // "subscribe"
+        || stripped.contains("subs") // "subscribers"
         || stripped.contains("follow")
         || stripped.contains("track")
     {
@@ -1648,7 +1651,7 @@ fn match_sort_bucket(label: &str) -> Option<SortBucket> {
         return Some(SortBucket::Added);
     }
 
-    if stripped.contains("late") // "latest"
+    if stripped.contains("latest")
         || stripped.contains("last")
         || stripped.contains("rec") // "recent"
         || stripped.contains("update")
@@ -1660,15 +1663,16 @@ fn match_sort_bucket(label: &str) -> Option<SortBucket> {
         || stripped.contains("rank")
         || stripped.contains("read")
         || stripped.contains("trend")
-        || stripped.contains("letti") // it. "read"
-        || stripped.contains("tend")  // es./it. "trending"
-        || stripped.contains("alta")  // pt. "trending"
-        || stripped.contains("theo")  // vi. "follow"
+        || stripped.contains("letti")  // it. "read"
+        || stripped.contains("tenden") // es./it. "trending" (tendencia/tendenza)
+        || stripped.contains("alta")   // pt. "trending"
+        || stripped.contains("theo")   // vi. "follow" (ok)
     {
         return Some(SortBucket::Popular);
     }
 
-    if stripped.contains("rat") // "rate/rating"
+    if stripped.contains("rate")
+        || stripped.contains("rating")
         || stripped.contains("all")
         || stripped.contains("score")
         || stripped.contains("cao") // vi. "high"

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -13,6 +13,7 @@ use tokio_util::sync::CancellationToken;
 use url::Url;
 use wasmi::*;
 use zip::ZipArchive;
+use unicode_normalization::UnicodeNormalization;
 
 use crate::{
     settings::SourceSettingValue,
@@ -348,7 +349,9 @@ pub struct BlockingSource {
     pub setting_definitions: Vec<SettingDefinition>,
     pub next_sdk: bool,
     pub features: SourceFeatures,
+    pub sort_filter: Option<SortFilterDef>,
 }
+
 #[cfg(feature = "all")]
 struct BlockingSource {
     id: String,
@@ -358,6 +361,7 @@ struct BlockingSource {
     setting_definitions: Vec<SettingDefinition>,
     pub next_sdk: bool,
     pub features: SourceFeatures,
+    pub sort_filter: Option<SortFilterDef>,
 }
 
 impl BlockingSource {
@@ -532,6 +536,12 @@ impl BlockingSource {
             );
         }
 
+        let sort_filter = archive
+            .by_name("Payload/filters.json")
+            .ok()
+            .and_then(|file| serde_json::from_reader::<_, Vec<SortFilterDef>>(file).ok())
+            .and_then(|filters| filters.into_iter().find(|f| f.filter_type == "sort"));
+
         Ok(Self {
             id,
             store,
@@ -540,6 +550,7 @@ impl BlockingSource {
             next_sdk: aidoku_sdk_next,
             setting_definitions,
             features,
+            sort_filter,
         })
     }
 
@@ -624,7 +635,73 @@ impl BlockingSource {
         .map(|mangas| (mangas, false))
     }
 
+    pub fn resolve_sort_filter(&self, bucket: SortBucket) -> Option<FilterValue> {
+        let filter = self.sort_filter.as_ref()?;
+
+        let matches: Vec<usize> = filter
+            .options
+            .iter()
+            .enumerate()
+            .filter(|(_, label)| match_sort_bucket(label) == Some(bucket))
+            .map(|(i, _)| i)
+            .collect();
+
+        if matches.len() != 1 {
+            return None;
+        }
+
+        Some(FilterValue::Sort {
+            id: filter.id.clone(),
+            index: matches[0] as i32,
+            ascending: false,
+        })
+    }
+
+    pub fn supported_sort_buckets(&self) -> Vec<SortBucket> {
+        let Some(filter) = &self.sort_filter else {
+            return vec![];
+        };
+        filter
+            .options
+            .iter()
+            .filter_map(|label| match_sort_bucket(label))
+            .collect()
+    }
+
+    pub fn search_mangas_sorted(
+        &mut self,
+        cancellation_token: CancellationToken,
+        query: String,
+        page: i32,
+        sort_bucket: Option<SortBucket>,
+    ) -> Result<(Vec<Manga>, bool)> {
+        if let Some(bucket) = sort_bucket {
+            let filter = match self.resolve_sort_filter(bucket) {
+                Some(f) => f,
+                None => return Ok((vec![], false)),
+            };
+
+            if !self.next_sdk {
+                return Ok((vec![], false));
+            }
+
+            return self
+                .get_search_manga_list_next(cancellation_token, query, page, vec![filter])
+                .map(|list| {
+                    let mangas = list
+                        .entries
+                        .into_iter()
+                        .map(|v| Manga::from(v, self.id.clone()))
+                        .collect::<Vec<_>>();
+                    (mangas, list.has_next_page)
+                });
+        }
+
+        self.search_mangas(cancellation_token, query, page)
+    }
+
     fn search_mangas_by_filters_inner(&mut self, filters: Vec<Filter>) -> Result<Vec<Manga>> {
+
         let wasm_function = self
             .instance
             .get_typed_func::<(i32, i32), i32>(&mut self.store, "get_manga_list")?;
@@ -1474,4 +1551,117 @@ impl BlockingSource {
 
         result
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum SortBucket {
+    Popular,
+    Views,
+    Rating,
+    Bookmarks,
+    Updated,
+    Added,
+}
+
+impl std::str::FromStr for SortBucket {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, ()> {
+        match s {
+            "popular" => Ok(SortBucket::Popular),
+            "views" => Ok(SortBucket::Views),
+            "rating" => Ok(SortBucket::Rating),
+            "bookmarks" => Ok(SortBucket::Bookmarks),
+            "updated" => Ok(SortBucket::Updated),
+            "added" => Ok(SortBucket::Added),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SortFilterDef {
+    #[serde(rename = "type")]
+    pub filter_type: String,
+    pub id: String,
+    pub options: Vec<String>,
+}
+
+const NON_SORT_SIGNAL: &[&str] = &[
+    "day", "daily",
+    "week",
+    "month",
+    "year",
+    "best", "match", "name", "old", "publish", "title",
+    "tang", // vi. "increasing" (excluded so "giảm"/decreasing wins — highest count first)
+    "meno", // it. "less"
+];
+
+fn strip_accents(s: &str) -> String {
+    s.nfkd().filter(|c| !c.is_mark_nonspacing()).collect()
+}
+
+fn match_sort_bucket(label: &str) -> Option<SortBucket> {
+    if label.chars().any(|c| c.is_ascii_digit()) {
+        return None;
+    }
+
+    let stripped = strip_accents(label).to_lowercase();
+
+    if NON_SORT_SIGNAL.iter().any(|t| stripped.contains(t)) {
+        return None;
+    }
+
+    if stripped.contains("view")
+        || stripped.contains("xem") // vi. "view"
+        || stripped.contains("vis") // pt./es. "views"
+    {
+        return Some(SortBucket::Views);
+    }
+
+    if stripped.contains("book") // "bookmark"
+        || stripped.contains("sub") // "subscribe"
+        || stripped.contains("follow")
+        || stripped.contains("track")
+    {
+        return Some(SortBucket::Bookmarks);
+    }
+
+    if stripped.contains("new")
+        || stripped.contains("add")
+        || stripped.contains("create")
+        || stripped.contains("novo")  // pt. "new"
+        || stripped.contains("nuevo") // es. "new"
+    {
+        return Some(SortBucket::Added);
+    }
+
+    if stripped.contains("late") // "latest"
+        || stripped.contains("last")
+        || stripped.contains("rec") // "recent"
+        || stripped.contains("update")
+    {
+        return Some(SortBucket::Updated);
+    }
+
+    if stripped.contains("popula") // "popular"
+        || stripped.contains("rank")
+        || stripped.contains("read")
+        || stripped.contains("trend")
+        || stripped.contains("letti") // it. "read"
+        || stripped.contains("tend")  // es./it. "trending"
+        || stripped.contains("alta")  // pt. "trending"
+        || stripped.contains("theo")  // vi. "follow"
+    {
+        return Some(SortBucket::Popular);
+    }
+
+    if stripped.contains("rat") // "rate/rating"
+        || stripped.contains("all")
+        || stripped.contains("score")
+        || stripped.contains("cao") // vi. "high"
+    {
+        return Some(SortBucket::Rating);
+    }
+
+    None
 }

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -552,7 +552,11 @@ impl BlockingSource {
         let sort_filter = archive
             .by_name("Payload/filters.json")
             .ok()
-            .and_then(|file| serde_json::from_reader::<_, Vec<SortFilterDef>>(file).ok())
+            .and_then(|file| {
+                serde_json::from_reader::<_, Vec<SortFilterDef>>(file)
+                    .map_err(|err| eprintln!("read file filters.json failed {}", err))
+                    .ok()
+            })
             .and_then(|filters| filters.into_iter().find(|f| f.filter_type == "sort"));
 
         Ok(Self {

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -551,9 +551,13 @@ impl BlockingSource {
             );
         }
 
-        let sort_buckets_cache = Self::read_sort_filter_from_archive(&mut archive)
-            .map(|filter| buckets_from_filter(&filter))
-            .unwrap_or_default();
+        let sort_buckets_cache = if aidoku_sdk_next {
+            Self::read_sort_filter_from_archive(&mut archive)
+                .map(|filter| buckets_from_filter(&filter))
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
 
         Ok(Self {
             id,

--- a/backend/shared/src/usecases/add_manga_to_library.rs
+++ b/backend/shared/src/usecases/add_manga_to_library.rs
@@ -2,11 +2,7 @@ use anyhow::Result;
 use tokio::time::{timeout, Duration};
 use tokio_util::sync::CancellationToken;
 
-use crate::{
-    database::Database,
-    model::{MangaId, MangaInformation},
-    source::Source,
-};
+use crate::{database::Database, model::MangaId, source::Source};
 
 pub async fn add_manga_to_library(
     token: &CancellationToken,
@@ -20,9 +16,7 @@ pub async fn add_manga_to_library(
         let fetch_task = source.get_manga_details(child_token.clone(), id.value().clone());
 
         if let Ok(Ok(manga)) = timeout(Duration::from_secs(seconds), fetch_task).await {
-            let _ = db
-                .upsert_cached_manga_information(&[MangaInformation::from(manga)])
-                .await;
+            let _ = db.upsert_cached_manga_information(&[manga.information]).await;
         }
     }
 

--- a/backend/shared/src/usecases/add_manga_to_library.rs
+++ b/backend/shared/src/usecases/add_manga_to_library.rs
@@ -1,8 +1,25 @@
 use anyhow::Result;
+use tokio::time::{timeout, Duration};
+use tokio_util::sync::CancellationToken;
 
-use crate::{database::Database, model::MangaId};
+use crate::{database::Database, model::MangaId, source::Source};
 
-pub async fn add_manga_to_library(db: &Database, id: MangaId) -> Result<()> {
+pub async fn add_manga_to_library(
+    token: &CancellationToken,
+    db: &Database,
+    source: &Source,
+    id: MangaId,
+    seconds: u64,
+) -> Result<()> {
+    if db.find_cached_manga_information(&id).await?.is_none() {
+        let child_token = token.child_token();
+        let fetch_task = source.get_manga_details(child_token.clone(), id.value().clone());
+
+        if let Ok(Ok(manga)) = timeout(Duration::from_secs(seconds), fetch_task).await {
+            let _ = db.upsert_cached_manga_information(&[manga.information]).await;
+        }
+    }
+
     db.add_manga_to_library(id).await?;
 
     Ok(())

--- a/backend/shared/src/usecases/add_manga_to_library.rs
+++ b/backend/shared/src/usecases/add_manga_to_library.rs
@@ -19,10 +19,14 @@ pub async fn add_manga_to_library(
         let child_token = token.child_token();
         let fetch_task = source.get_manga_details(child_token.clone(), id.value().clone());
 
-        if let Ok(Ok(manga)) = timeout(Duration::from_secs(seconds), fetch_task).await {
-            let _ = db
-                .upsert_cached_manga_information(&[MangaInformation::from(manga)])
-                .await;
+        match timeout(Duration::from_secs(seconds), fetch_task).await {
+            Ok(Ok(manga)) => {
+                let _ = db
+                    .upsert_cached_manga_information(&[MangaInformation::from(manga)])
+                    .await;
+            }
+            Err(_) => child_token.cancel(),
+            Ok(Err(_)) => {}
         }
     }
 

--- a/backend/shared/src/usecases/add_manga_to_library.rs
+++ b/backend/shared/src/usecases/add_manga_to_library.rs
@@ -2,7 +2,11 @@ use anyhow::Result;
 use tokio::time::{timeout, Duration};
 use tokio_util::sync::CancellationToken;
 
-use crate::{database::Database, model::MangaId, source::Source};
+use crate::{
+    database::Database,
+    model::{MangaId, MangaInformation},
+    source::Source,
+};
 
 pub async fn add_manga_to_library(
     token: &CancellationToken,
@@ -16,7 +20,9 @@ pub async fn add_manga_to_library(
         let fetch_task = source.get_manga_details(child_token.clone(), id.value().clone());
 
         if let Ok(Ok(manga)) = timeout(Duration::from_secs(seconds), fetch_task).await {
-            let _ = db.upsert_cached_manga_information(&[manga.information]).await;
+            let _ = db
+                .upsert_cached_manga_information(&[MangaInformation::from(manga)])
+                .await;
         }
     }
 

--- a/backend/shared/src/usecases/list_installed_sources.rs
+++ b/backend/shared/src/usecases/list_installed_sources.rs
@@ -4,7 +4,17 @@ pub fn list_installed_sources(source_collection: &impl SourceCollection) -> Vec<
     let mut source_informations: Vec<SourceInformation> = source_collection
         .sources()
         .into_iter()
-        .map(|source| source.manifest().into())
+        .map(|source| {
+            let manifest_info: SourceInformation = source.manifest().into();
+            SourceInformation {
+                supported_sort_buckets: source
+                    .supported_sort_buckets()
+                    .into_iter()
+                    .map(|b| format!("{:?}", b).to_lowercase())
+                    .collect(),
+                ..manifest_info
+            }
+        })
         .collect();
 
     source_informations.sort_by_key(|source| source.name.clone());

--- a/backend/shared/src/usecases/refresh_manga_details.rs
+++ b/backend/shared/src/usecases/refresh_manga_details.rs
@@ -38,12 +38,14 @@ pub async fn refresh_manga_details(
         }
     };
 
-    db.upsert_cached_manga_details(id, &manga_details).await?;
+    if db.find_cached_manga_information(id).await?.is_some() {
+        db.upsert_cached_manga_details(id, &manga_details).await?;
 
-    if let Some(url) = &manga_details.cover_url {
-        chapter_storage
-            .cached_poster(token, id, || source.get_image_request(url.to_owned(), None))
-            .await?;
+        if let Some(url) = &manga_details.cover_url {
+            chapter_storage
+                .cached_poster(token, id, || source.get_image_request(url.to_owned(), None))
+                .await?;
+        }
     }
 
     Ok(manga_details.status)

--- a/backend/shared/src/usecases/search_mangas.rs
+++ b/backend/shared/src/usecases/search_mangas.rs
@@ -119,39 +119,45 @@ pub async fn search_mangas(
                             }
                         };
 
-                    // Write through to the database
-                    let _ = db
-                        .upsert_cached_manga_information(&manga_informations)
-                        .await;
-
-                    if settings.search_view_mode != SearchViewMode::Base {
-                        // Download posters concurrently so cover/grid view can render them
-                        let poster_items: Vec<(MangaId, url::Url)> = manga_informations
-                            .iter()
-                            .filter_map(|info| {
-                                info.cover_url
-                                    .as_ref()
-                                    .map(|url| (info.id.clone(), url.clone()))
-                            })
-                            .collect();
-                        stream::iter(poster_items)
-                            .map(|(id, url)| {
-                                let chapter_storage = chapter_storage.clone();
-                                let source = source.clone();
-                                let token = token.clone();
-                                async move {
-                                    let _ = timeout(
-                                        Duration::from_secs(POSTER_DOWNLOAD_TIMEOUT_SECS),
-                                        chapter_storage.cached_poster(&token, &id, || {
-                                            source.get_image_request(url.clone(), None)
-                                        }),
-                                    )
-                                    .await;
-                                }
-                            })
-                            .buffered(CONCURRENT_POSTER_DOWNLOADS)
-                            .collect::<Vec<_>>()
+                    // Bucket browsing (Popular/Views/Rating/Bookmarks) doesn't persist anything
+                    // by itself — the manga's info gets backfilled once it's actually added to
+                    // the library, so plain browsing never leaves a database row or a cover file
+                    // behind.
+                    if sort_bucket.is_none() {
+                        // Write through to the database
+                        let _ = db
+                            .upsert_cached_manga_information(&manga_informations)
                             .await;
+
+                        if settings.search_view_mode != SearchViewMode::Base {
+                            // Download posters concurrently so cover/grid view can render them
+                            let poster_items: Vec<(MangaId, url::Url)> = manga_informations
+                                .iter()
+                                .filter_map(|info| {
+                                    info.cover_url
+                                        .as_ref()
+                                        .map(|url| (info.id.clone(), url.clone()))
+                                })
+                                .collect();
+                            stream::iter(poster_items)
+                                .map(|(id, url)| {
+                                    let chapter_storage = chapter_storage.clone();
+                                    let source = source.clone();
+                                    let token = token.clone();
+                                    async move {
+                                        let _ = timeout(
+                                            Duration::from_secs(POSTER_DOWNLOAD_TIMEOUT_SECS),
+                                            chapter_storage.cached_poster(&token, &id, || {
+                                                source.get_image_request(url.clone(), None)
+                                            }),
+                                        )
+                                        .await;
+                                    }
+                                })
+                                .buffered(CONCURRENT_POSTER_DOWNLOADS)
+                                .collect::<Vec<_>>()
+                                .await;
+                        }
                     }
 
                     // Fetch unread chapters count for each manga

--- a/backend/shared/src/usecases/search_mangas.rs
+++ b/backend/shared/src/usecases/search_mangas.rs
@@ -32,7 +32,9 @@ pub async fn search_mangas(
     exclude: &Option<Vec<String>>,
     page: i32,
     seconds: u64,
+    sort_bucket: Option<crate::source::SortBucket>,
 ) -> Result<(Vec<Manga>, Vec<SearchError>, bool), Error> {
+
     // FIXME this looks awful
     let query = &query;
 
@@ -73,7 +75,7 @@ pub async fn search_mangas(
                     let token = cancellation_token.child_token();
 
                     let fetch_task =
-                        async { source.search_mangas(token.clone(), query, page).await };
+                        async { source.search_mangas_sorted(token.clone(), query, page, sort_bucket).await };
 
                     let (manga_informations, has_next, error) =
                         match timeout(Duration::from_secs(seconds), fetch_task).await {

--- a/frontend/rakuyomi.koplugin/Backend.lua
+++ b/frontend/rakuyomi.koplugin/Backend.lua
@@ -218,6 +218,7 @@ end
 --- @field id string The ID of the source.
 --- @field name string The name of the source.
 --- @field version number The version of the source.
+--- @field supported_sort_buckets string[] Sort buckets this source's `sort` filter maps to.
 --- @field source_of_source string|nil The domain source load source.
 
 --- @class Manga

--- a/frontend/rakuyomi.koplugin/Backend.lua
+++ b/frontend/rakuyomi.koplugin/Backend.lua
@@ -442,7 +442,7 @@ end
 --- @param exclude string[]|nil
 --- @param page number|nil
 --- @return SuccessfulResponse<[Manga[], SearchError[], boolean]>|ErrorResponse
-function Backend.searchMangas(cancel_id, search_text, exclude, page)
+function Backend.searchMangas(cancel_id, search_text, exclude, page, sort_bucket)
   return Backend.requestJson({
     path = "/mangas",
     query_params = {
@@ -450,6 +450,7 @@ function Backend.searchMangas(cancel_id, search_text, exclude, page)
       exclude = exclude and table.concat(exclude, ",") or nil,
       cancel_id = cancel_id,
       page = page,
+      sort = sort_bucket,
     }
   })
 end

--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -18,6 +18,7 @@ local VerticalSpan = require("ui/widget/verticalspan")
 local InfoMessage = require("ui/widget/infomessage")
 local addToPlaylist = require("handlers/addToPlaylist")
 local NetworkMgr = require("ui/network/manager")
+local hasValue = require("utils/hasValue")
 local logger = require("logger")
 
 local Backend = require("Backend")
@@ -1134,6 +1135,21 @@ end
 
 --- @private
 function LibraryView:openSearchMangasDialog()
+  local exclude_key = "exlucde_source_ids_select_search"
+  local excluded = G_reader_settings:readSetting(exclude_key, {})
+  local supported = { views = false, rating = false, popular = false, bookmarks = false }
+
+  local sources_response = Backend.listInstalledSources()
+  if sources_response.type == 'SUCCESS' then
+    for _, source in ipairs(sources_response.body) do
+      if not hasValue(excluded, source.id) then
+        for _, bucket in ipairs(source.supported_sort_buckets) do
+          supported[bucket] = true
+        end
+      end
+    end
+  end
+
   local dialog
   dialog = InputDialog:new {
     title = _("Manga search..."),
@@ -1156,9 +1172,47 @@ function LibraryView:openSearchMangasDialog()
           callback = function()
             UIManager:close(dialog)
 
-            self:searchMangas(dialog:getInputText(), G_reader_settings:readSetting(
-              "exlucde_source_ids_select_search", {}
-            ))
+            self:searchMangas(dialog:getInputText(), excluded)
+          end,
+        },
+      },
+      {
+        {
+          text = _("Views"),
+          enabled = supported.views,
+          callback = function()
+            UIManager:close(dialog)
+
+            self:searchMangas("", excluded, "views")
+          end,
+        },
+        {
+          text = _("Rating"),
+          enabled = supported.rating,
+          callback = function()
+            UIManager:close(dialog)
+
+            self:searchMangas("", excluded, "rating")
+          end,
+        },
+      },
+      {
+        {
+          text = _("Popular"),
+          enabled = supported.popular,
+          callback = function()
+            UIManager:close(dialog)
+
+            self:searchMangas("", excluded, "popular")
+          end,
+        },
+        {
+          text = _("Bookmarks"),
+          enabled = supported.bookmarks,
+          callback = function()
+            UIManager:close(dialog)
+
+            self:searchMangas("", excluded, "bookmarks")
           end,
         },
       },
@@ -1425,13 +1479,13 @@ function LibraryView:openCleanerDialog()
 end
 
 --- @private
-function LibraryView:searchMangas(search_text, exclude)
+function LibraryView:searchMangas(search_text, exclude, sort_bucket)
   Trapper:wrap(function()
     local onReturnCallback = function()
       self:fetchAndShow(self.current_playlist, nil, { hideTopClose = self.hide_top_close })
     end
 
-    if MangaSearchResults:searchAndShow(search_text, exclude, onReturnCallback) then
+    if MangaSearchResults:searchAndShow(search_text, exclude, sort_bucket, onReturnCallback) then
       self:onClose(true)
     end
   end)

--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -1143,7 +1143,7 @@ function LibraryView:openSearchMangasDialog()
   if sources_response.type == 'SUCCESS' then
     for _, source in ipairs(sources_response.body) do
       if not hasValue(excluded, source.id) then
-        for _, bucket in ipairs(source.supported_sort_buckets) do
+for _, bucket in ipairs(source.supported_sort_buckets or {}) do
           supported[bucket] = true
         end
       end

--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -204,11 +204,11 @@ end
 --- @param exclude string[]
 --- @param onReturnCallback any
 --- @return boolean
-function MangaSearchResults:searchAndShow(search_text, exclude, onReturnCallback)
+function MangaSearchResults:searchAndShow(search_text, exclude, sort_bucket, onReturnCallback)
   local cancel_id = Backend.createCancelId()
   local response, cancelled = LoadingDialog:showAndRun(
     _("Searching for") .. " \"" .. search_text .. "\"",
-    function() return Backend.searchMangas(cancel_id, search_text, exclude) end,
+    function() return Backend.searchMangas(cancel_id, search_text, exclude, nil, sort_bucket) end,
     function()
       Backend.cancel(cancel_id)
       local cancelledMessage = InfoMessage:new {
@@ -235,6 +235,7 @@ function MangaSearchResults:searchAndShow(search_text, exclude, onReturnCallback
     results = results,
     search_text = search_text,
     exclude = exclude,
+    sort_bucket = sort_bucket,
     result_page = 1,
     has_next_page = has_next_page,
     on_return_callback = onReturnCallback,
@@ -260,7 +261,7 @@ end
 function MangaSearchResults:loadNextPage()
   Trapper:wrap(function()
     local search_text = self.search_text
-    if not search_text or search_text == "" then
+    if (not search_text or search_text == "") and not self.sort_bucket then
       return
     end
 
@@ -268,7 +269,7 @@ function MangaSearchResults:loadNextPage()
     local next_page = self.result_page + 1
     local response, cancelled = LoadingDialog:showAndRun(
       _("Searching for") .. " \"" .. search_text .. "\"",
-      function() return Backend.searchMangas(cancel_id, search_text, self.exclude, next_page) end,
+      function() return Backend.searchMangas(cancel_id, search_text, self.exclude, next_page, self.sort_bucket) end,
       function()
         Backend.cancel(cancel_id)
 


### PR DESCRIPTION
I wasn't sure what to read next, so I figured it'd be nice to have quick
access to the top/popular manga per source directly in Rakuyomi — fetching
the sorted manga list for a given criteria, without having to type a
search query.

The problem is that almost every source is different — there's no shared
standard for "popular"/"trending"/"rating"/"follows". I couldn't think of
a better way to handle this than keyword-matching against the sort options
each source already declares in its filters.json, rather than maintaining
per-source config (unmanageable long-term with this many sources).

This adds 4 quick-search buttons (Popular, Views, Rating, Bookmarks) to
the search dialog. Each one matches whichever sort option best fits, with
no per-source configuration required.

The keyword matching mainly targets English, since most sources declare
their sort labels in English. A handful of other languages get matched
too, but mostly by coincidence rather than deliberate i18n support: some
words happen to share the same root as their English counterpart (e.g.
Spanish/Portuguese "vis-" for views), and a few others were quick wins I
noticed while testing (e.g. Vietnamese "cao" for a high rating). It's not
meant to be a real multi-language solution, just whatever fell out of the
English-first matching for free.

I make sure to never guess: if a source has two sort options that would
both match the same bucket (e.g. "Newest" and "Oldest" both matching
"Added" without extra logic), the source is simply skipped for that
bucket rather than risking a wrong pick. I'd rather have no results than
silently wrong ones.

With this approach I'm handling 97.6% of the sources that actually declare
a `sort` filter (41/42, EN/multi sources tested). Sources with no sort
filter at all obviously can't be matched — that's not a limitation of the
matching logic, just nothing to match against.

Implementation details:
- Buttons are disabled when no active (non-excluded) source supports that
  sort bucket, reusing the existing source-exclusion search setting.
- A source with no matching option, or an ambiguous match, simply
  contributes no results for that bucket instead of guessing.
- Updated/Added are also resolved server-side but don't have a button yet.
- "Next page" pagination now also works for sort-bucket searches, not
  just text searches.
