### PR TITLE
fix: preserve hideTopClose state when opening playlist view

### DIFF
--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -1128,7 +1128,7 @@ function LibraryView:openPlaylistDialog()
       if need_close then
         self:onClose(true)
       end
-    end, { hideTopClose = true })
+    end, { hideTopClose = self.hide_top_close })
   end)
 end
 


### PR DESCRIPTION
Closes #268

### Summary
Preserves the `hideTopClose` state when navigating to a playlist view from `openPlaylistDialog()`.

### Problem
Previously, `openPlaylistDialog()` hardcoded `{ hideTopClose = true }` when calling `LibraryView:fetchAndShow()`. This forced `hide_top_close = true` on playlist views even when Rakuyomi was opened standalone, hiding the top close ('X') button and leaving users stuck without a way to close the view.

### Solution
Updated `openPlaylistDialog()` to pass `{ hideTopClose = self.hide_top_close }` instead of hardcoding `true`. This:
- Ensures the top close ('X') button remains visible when Rakuyomi is opened normally.
- Preserves `hideTopClose = true` if Rakuyomi was opened by an external plugin that requested hiding the top close button.
