### PR TITLE
feat: ask to mark previous chapters as read when marking a chapter read

### DIFF
--- a/frontend/rakuyomi.koplugin/ChapterListing.lua
+++ b/frontend/rakuyomi.koplugin/ChapterListing.lua
@@ -702,9 +702,11 @@ function ChapterListing:markChaptersAs(chapters, value)
     local mark_response = LoadingDialog:showAndRun(
       (value and _("Marking") or _("Un-marking")) .. " " .. _("chapters..."),
       function()
-        for __, chapter in ipairs(chapters) do
+        for i, chapter in ipairs(chapters) do
           local result = Backend.markChapterAsRead(self.manga.source.id, self.manga.id, chapter.id, value)
           if result.type == 'ERROR' then
+            result.completed = i - 1
+
             return result
           end
         end
@@ -713,6 +715,13 @@ function ChapterListing:markChaptersAs(chapters, value)
     )
 
     if mark_response.type == 'ERROR' then
+      for i = 1, mark_response.completed or 0 do
+        chapters[i].read = value
+      end
+      if (mark_response.completed or 0) > 0 then
+        self:updateItems()
+      end
+
       ErrorDialog:show(mark_response.message)
 
       return

--- a/frontend/rakuyomi.koplugin/ChapterListing.lua
+++ b/frontend/rakuyomi.koplugin/ChapterListing.lua
@@ -36,6 +36,7 @@ local isBeforeChapter = require("utils/isBeforeChapter")
 local filterChaptersByLang = require("utils/filterChaptersByLang")
 local findLastRead = require("utils/findLastRead")
 local getChapterDisplayName = require("utils/getChapterDisplayName")
+local getChaptersBeforeChapter = require("utils/getChaptersBeforeChapter")
 
 local TrackingMenu = require("TrackingMenu")
 local findNextChapter = require("chapters/findNextChapter")
@@ -581,7 +582,38 @@ function ChapterListing:onContextMenuChoice(item)
         end,
         callback = function()
           UIManager:close(dialog_context_menu)
-          self:markChapterAs(chapter, not chapter.read)
+
+          if chapter.read then
+            self:markChapterAs(chapter, false)
+            return
+          end
+
+          local chapters_before = getChaptersBeforeChapter(self.chapters, chapter)
+          local has_unread_before = false
+          for __, c in ipairs(chapters_before) do
+            if not c.read then
+              has_unread_before = true
+              break
+            end
+          end
+
+          if not has_unread_before then
+            self:markChapterAs(chapter, true)
+            return
+          end
+
+          UIManager:show(ConfirmBox:new {
+            text = _("Do you also want to mark all previous chapters as read?"),
+            ok_text = _("Yes"),
+            cancel_text = _("No"),
+            ok_callback = function()
+              table.insert(chapters_before, chapter)
+              self:markChaptersAs(chapters_before, true)
+            end,
+            cancel_callback = function()
+              self:markChapterAs(chapter, true)
+            end,
+          })
         end
       }
     },
@@ -658,6 +690,37 @@ function ChapterListing:markChapterAs(chapter, value)
     end
 
     chapter.read = value
+    self:updateItems()
+  end)
+end
+
+--- @private
+--- @param chapters Chapter[]
+--- @param value boolean
+function ChapterListing:markChaptersAs(chapters, value)
+  Trapper:wrap(function()
+    local mark_response = LoadingDialog:showAndRun(
+      (value and _("Marking") or _("Un-marking")) .. " " .. _("chapters..."),
+      function()
+        for __, chapter in ipairs(chapters) do
+          local result = Backend.markChapterAsRead(self.manga.source.id, self.manga.id, chapter.id, value)
+          if result.type == 'ERROR' then
+            return result
+          end
+        end
+        return { type = 'SUCCESS' }
+      end
+    )
+
+    if mark_response.type == 'ERROR' then
+      ErrorDialog:show(mark_response.message)
+
+      return
+    end
+
+    for __, chapter in ipairs(chapters) do
+      chapter.read = value
+    end
     self:updateItems()
   end)
 end

--- a/frontend/rakuyomi.koplugin/utils/getChaptersBeforeChapter.lua
+++ b/frontend/rakuyomi.koplugin/utils/getChaptersBeforeChapter.lua
@@ -1,0 +1,33 @@
+local isBeforeChapter = require("utils/isBeforeChapter")
+
+--- Returns all chapters from `chapters` that come before `chapter` in reading order,
+--- using the same ordering rules as the chapter list display.
+--- @param chapters Chapter[]
+--- @param chapter Chapter
+--- @return Chapter[]
+local function getChaptersBeforeChapter(chapters, chapter)
+  local indexed = {}
+  local target
+  for i, ch in ipairs(chapters) do
+    local entry = { index = i, volume_num = ch.volume_num, chapter_num = ch.chapter_num, ch = ch }
+    indexed[i] = entry
+    if ch.id == chapter.id then
+      target = entry
+    end
+  end
+
+  local result = {}
+  if not target then
+    return result
+  end
+
+  for _, entry in ipairs(indexed) do
+    if entry.ch.id ~= chapter.id and isBeforeChapter(entry, target) then
+      table.insert(result, entry.ch)
+    end
+  end
+
+  return result
+end
+
+return getChaptersBeforeChapter


### PR DESCRIPTION
When long-pressing a chapter and choosing "Mark read", if there are still-unread chapters before it, prompt whether to mark those as read too, so catching up on a series doesn't require marking each chapter individually.