### PR TITLE
fix: make cookie store re-init across server restarts in rakuyomi-bridge

### DIFF
--- a/backend/shared/src/cookie_store.rs
+++ b/backend/shared/src/cookie_store.rs
@@ -151,6 +151,18 @@ pub fn init_cookie_store() {
 
 pub fn init_cookie_store_with_path(path: &Path) -> Result<()> {
     if COOKIE_STORE.get().is_some() {
+        let new_path = path.to_string_lossy().to_string();
+        match COOKIE_STORE_PATH.get() {
+            Some(existing_path) if existing_path != &new_path => {
+                return Err(anyhow::anyhow!(
+                    "cookie store already initialized with a different path ({existing_path} != {new_path})"
+                ));
+            }
+            Some(_) => {}
+            None => {
+                let _ = COOKIE_STORE_PATH.set(new_path);
+            }
+        }
         return Ok(());
     }
 

--- a/backend/shared/src/cookie_store.rs
+++ b/backend/shared/src/cookie_store.rs
@@ -150,6 +150,10 @@ pub fn init_cookie_store() {
 }
 
 pub fn init_cookie_store_with_path(path: &Path) -> Result<()> {
+    if COOKIE_STORE.get().is_some() {
+        return Ok(());
+    }
+
     let store = CookieStoreData::load_from_file(path).unwrap_or_default();
     SYNC_HASH.get_or_init(|| RwLock::new(sync_hash_from_store(&store)));
     COOKIE_STORE

--- a/backend/shared/src/cookie_store.rs
+++ b/backend/shared/src/cookie_store.rs
@@ -150,6 +150,7 @@ pub fn init_cookie_store() {
 }
 
 pub fn init_cookie_store_with_path(path: &Path) -> Result<()> {
+    #[cfg(target_os = "android")]
     if COOKIE_STORE.get().is_some() {
         let new_path = path.to_string_lossy().to_string();
         match COOKIE_STORE_PATH.get() {


### PR DESCRIPTION
This fixes a bug in rakuyomi-bridge:

Reproduce bug:
1. Start koreader and rakuyomi -> bridge starts
2. Close koreader -> bridge is still running
3. Start  koreader rakuyomi again -> bridge silently crashes when trying to re-initialize the cookie store since it's already initialized. Shows as running even though it has failed.

Workaround was to force close rakuyomi-bridge to get it do a clean initialization of cookies.

This simple fix checks if the cookie store is already initialized and in that case uses the existing store.