### PR TITLE
Use built in math.floor instead of optmath.

### DIFF
--- a/frontend/rakuyomi.koplugin/patch/MenuCustom.lua
+++ b/frontend/rakuyomi.koplugin/patch/MenuCustom.lua
@@ -205,7 +205,7 @@ function MenuCustom:_recalculateDimen(no_recalculate_dimen)
       local portrait_rows = math.floor(portrait_available_height /
         ((self.inner_dimen.w / columns) * 4 / 3 + grid_text_height))
       if portrait_rows < 2 then portrait_rows = 2 end
-      rows = Math.floor(available_height / (portrait_available_height / portrait_rows))
+      rows = math.floor(available_height / (portrait_available_height / portrait_rows))
     end
     self.perpage = rows * columns
     perpage = self.perpage


### PR DESCRIPTION
Fixed an error I was having using the Desktop Linux version of Rakuyomi.

After going full screen mode in rakuyomi on koreader it crashed. After relaunching koreader it loaded in with a large weird resolution and rakuyomi would crash on boot with an error referencing Math.floor

08/04/26-13:20:08 INFO Requesting to /library
/usr/lib/koreader/luajit: plugins/rakuyomi.koplugin/patch/MenuCustom.lua:208: attempt to call field 'floor' (a nil value)

The line was using an optmath call for Math.floor() when we could just use built in lua math.floor() call.