### PR TITLE
fix: 7 generic bug fixes reconstructed from upstream-fixes (rebased, LNReader-free)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,44 @@ dev.db
 node_modules
 
 /BUILD_INFO.json
+
+# LNReader integration: Claude Code working notes (feasibility research,
+# phase handoffs, investigation findings) -- session-scratch, not shipped
+# documentation, kept local only. This also covers docs/lnreader/test_home/
+# (a local server home directory used for real, end-to-end manual testing
+# against the live HTTP API), whose churn was previously excluded on its own.
+docs/lnreader/
+
+# Claude Code's own runtime state for this repo (scheduled tasks, worktree/
+# checkpoint/mailbox bookkeeping, agent registry/memory) -- tooling-local,
+# regenerated per machine, never meant to be shared via git. Previously
+# only excluded per-clone via .git/info/exclude (not shared with a fresh
+# clone); formalized here so it can't be accidentally committed from any
+# checkout.
+.claude/
+
+# codebase-memory-mcp local knowledge graph cache (per-project, regenerated)
+.codebase-memory/
+
+# codegraph local index (per-project, regenerated)
+.codegraph/
+
+# Local agent tooling (not upstream): agent-browser skill, session state
+.agents/
+
+# OhMyOpenCode session/plan state (local-only)
+.omo/
+
+# OpenCode local config + OpenSpec workflow files (not upstream).
+# NOTE: .opencode/skills/rakuyomi-topzone-gesture/ IS tracked upstream --
+# only the local openspec-* skills and commands are ignored.
+opencode.json
+skills-lock.json
+openspec/
+.opencode/commands/
+.opencode/skills/openspec-*/
+.opencode/perf-skills/
+
+# git worktree checkouts used for parallel branch work (per-machine, not
+# meant to be shared via git)
+.slim/

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -16,23 +16,10 @@ use shared::usecases;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-use crate::model::{Chapter, Manga};
+use crate::model::{resolve_manga_covers, Chapter, Manga};
 use crate::source_extractor::SourceExtractor;
 use crate::state::State;
 use crate::AppError;
-
-fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
-    match url::Url::from_file_path(path) {
-        Ok(url) => Some(url),
-        Err(_) => match path.canonicalize() {
-            Ok(canonical_path) => url::Url::from_file_path(canonical_path).ok(),
-            Err(e) => {
-                println!("Error canonicalizing path: {}", e);
-                None
-            }
-        },
-    }
-}
 
 pub fn routes() -> Router<State> {
     Router::new()
@@ -154,13 +141,7 @@ async fn get_manga_library(
         usecases::get_manga_library(&database, &*source_manager, library_sorting_mode).await?;
 
     if settings.library_view_mode != shared::settings::LibraryViewMode::Base {
-        for manga in mangas.iter_mut() {
-            if manga.information.cover_url.is_some() {
-                manga.information.cover_url = chapter_storage
-                    .poster_exists(&manga.information.id)
-                    .and_then(|path| path_to_file_url(&path));
-            }
-        }
+        resolve_manga_covers(&mut mangas, &chapter_storage);
     }
 
     Ok(Json(
@@ -339,13 +320,7 @@ async fn get_mangas(
         .map_err(AppError::from_search_mangas_error)?;
 
     if settings.search_view_mode != shared::settings::SearchViewMode::Base {
-        for manga in mangas.iter_mut() {
-            if manga.information.cover_url.is_some() {
-                manga.information.cover_url = chapter_storage
-                    .poster_exists(&manga.information.id)
-                    .and_then(|path| path_to_file_url(&path));
-            }
-        }
+        resolve_manga_covers(&mut mangas, &chapter_storage);
     }
 
     let results = mangas.into_iter().map(Manga::from).collect();
@@ -616,13 +591,8 @@ async fn mark_chapters_as_read(
 ) -> Result<Json<Option<usize>>, AppError> {
     let manga_id = MangaId::from(params);
 
-    let (delete_downloaded_after_read, tracking_auto_sync) = {
-        let settings = settings.lock().await;
-        (
-            settings.delete_downloaded_after_read,
-            settings.tracking_auto_sync,
-        )
-    };
+    let (delete_downloaded_after_read, tracking_auto_sync) =
+        read_read_tracking_settings(&settings).await;
     let chapter_storage = &*chapter_storage.lock().await;
 
     let count = usecases::mark_chapters_as_read(
@@ -749,13 +719,8 @@ async fn mark_chapter_as_read(
 ) -> Result<Json<()>, AppError> {
     let chapter_id = ChapterId::from(params);
 
-    let (delete_downloaded_after_read, tracking_auto_sync) = {
-        let settings = settings.lock().await;
-        (
-            settings.delete_downloaded_after_read,
-            settings.tracking_auto_sync,
-        )
-    };
+    let (delete_downloaded_after_read, tracking_auto_sync) =
+        read_read_tracking_settings(&settings).await;
     let chapter_storage = chapter_storage.lock().await;
 
     usecases::mark_chapter_as_read(
@@ -1072,6 +1037,15 @@ impl Drop for TokenGuard {
             });
         }
     }
+}
+
+async fn read_read_tracking_settings(settings: &Mutex<shared::settings::Settings>) -> (bool, bool) {
+    let settings = settings.lock().await;
+
+    (
+        settings.delete_downloaded_after_read,
+        settings.tracking_auto_sync,
+    )
 }
 
 async fn create_token(

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -548,7 +548,7 @@ async fn refresh_manga_chapters(
 
     let token = create_token(cancel_token_store, cancel_id).await;
 
-    let _ = usecases::refresh_manga_chapters(&token.0, &database, &source, &manga_id, 60).await;
+    usecases::refresh_manga_chapters(&token.0, &database, &source, &manga_id, 60).await?;
 
     Ok(Json(()))
 }
@@ -597,15 +597,8 @@ async fn refresh_manga_details(
     let chapter_storage = &*chapter_storage.lock().await;
     let token = create_token(cancel_token_store, cancel_id).await;
 
-    let _ = usecases::refresh_manga_details(
-        &token.0,
-        &database,
-        chapter_storage,
-        &source,
-        &manga_id,
-        60,
-    )
-    .await;
+    usecases::refresh_manga_details(&token.0, &database, chapter_storage, &source, &manga_id, 60)
+        .await?;
 
     Ok(Json(()))
 }

--- a/backend/server/src/model.rs
+++ b/backend/server/src/model.rs
@@ -1,12 +1,38 @@
 use serde::Serialize;
 
 use shared::{
+    chapter_storage::ChapterStorage,
     model::{
         Chapter as DomainChapter, Manga as DomainManga,
         SourceInformation as DomainSourceInformation,
     },
     source::model::MangaViewer,
 };
+
+/// Resolves each manga's cover to a local `file://` URL served from the
+/// chapter storage's downloaded poster, if one exists.
+pub fn resolve_manga_covers(mangas: &mut [DomainManga], chapter_storage: &ChapterStorage) {
+    for manga in mangas.iter_mut() {
+        if manga.information.cover_url.is_some() {
+            manga.information.cover_url = chapter_storage
+                .poster_exists(&manga.information.id)
+                .and_then(|path| path_to_file_url(&path));
+        }
+    }
+}
+
+pub fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
+    match url::Url::from_file_path(path) {
+        Ok(url) => Some(url),
+        Err(_) => match path.canonicalize() {
+            Ok(canonical_path) => url::Url::from_file_path(canonical_path).ok(),
+            Err(e) => {
+                println!("Error canonicalizing path: {}", e);
+                None
+            }
+        },
+    }
+}
 
 #[derive(Serialize)]
 pub struct SourceInformation {

--- a/backend/server/src/model.rs
+++ b/backend/server/src/model.rs
@@ -10,17 +10,22 @@ use shared::{
 };
 
 /// Resolves each manga's cover to a local `file://` URL served from the
-/// chapter storage's downloaded poster, if one exists.
+/// chapter storage's downloaded poster, if one exists -- otherwise leaves the
+/// existing (typically remote) `cover_url` as-is, rather than clearing it.
 pub fn resolve_manga_covers(mangas: &mut [DomainManga], chapter_storage: &ChapterStorage) {
     for manga in mangas.iter_mut() {
-        if manga.information.cover_url.is_some() {
-            manga.information.cover_url = chapter_storage
-                .poster_exists(&manga.information.id)
-                .and_then(|path| path_to_file_url(&path));
+        if let Some(local_cover_url) = chapter_storage
+            .poster_exists(&manga.information.id)
+            .and_then(|path| path_to_file_url(&path))
+        {
+            manga.information.cover_url = Some(local_cover_url);
         }
     }
 }
 
+/// Converts a local filesystem path into a `file://` URL, falling back to
+/// canonicalizing the path first if the direct conversion fails (e.g. for a
+/// relative path `Url::from_file_path` can't handle on its own).
 pub fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
     match url::Url::from_file_path(path) {
         Ok(url) => Some(url),

--- a/backend/server/src/playlists/routes.rs
+++ b/backend/server/src/playlists/routes.rs
@@ -1,4 +1,4 @@
-use crate::model::Manga;
+use crate::model::{resolve_manga_covers, Manga};
 use axum::extract::{Path, State as StateExtractor};
 use axum::routing::{delete, get, post, put};
 use axum::{Json, Router};
@@ -93,25 +93,7 @@ async fn get_mangas_in_playlist(
     .await?;
 
     if settings.library_view_mode != shared::settings::LibraryViewMode::Base {
-        for manga in mangas.iter_mut() {
-            if manga.information.cover_url.is_some() {
-                manga.information.cover_url =
-                    if let Some(path) = chapter_storage.poster_exists(&manga.information.id) {
-                        match url::Url::from_file_path(&path) {
-                            Ok(url) => Some(url),
-                            Err(_) => match path.canonicalize() {
-                                Ok(canonical_path) => url::Url::from_file_path(canonical_path).ok(),
-                                Err(e) => {
-                                    println!("Error canonicalizing path: {}", e);
-                                    None
-                                }
-                            },
-                        }
-                    } else {
-                        None
-                    };
-            }
-        }
+        resolve_manga_covers(&mut mangas, &chapter_storage);
     }
 
     Ok(Json(

--- a/backend/shared/src/chapter_downloader.rs
+++ b/backend/shared/src/chapter_downloader.rs
@@ -181,6 +181,39 @@ fn zip_comment(chapter_id: &ChapterId) -> String {
     .to_string()
 }
 
+fn add_epub_page(
+    epub: &mut EpubBuilder<ZipLibrary>,
+    idx: usize,
+    title: String,
+    html: &str,
+) -> anyhow::Result<()> {
+    epub.add_content(
+        EpubContent::new(
+            format!("pages/page_{}.xhtml", idx + 1),
+            Cursor::new(create_xhtml(&title, html)),
+        )
+        .title(title)
+        .reftype(ReferenceType::Text),
+    )?;
+
+    Ok(())
+}
+
+fn store_epub_image_resource(
+    epub: &mut EpubBuilder<ZipLibrary>,
+    index_image: &mut usize,
+    image_bytes: &[u8],
+    ext: &str,
+    mime: &str,
+) -> anyhow::Result<String> {
+    let filename = format!("images/img_{}.{}", index_image, ext);
+    *index_image += 1;
+
+    epub.add_resource(&filename, Cursor::new(image_bytes), mime)?;
+
+    Ok(filename)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn download_chapter_pages_as_cbz<W>(
     cancel_token: &CancellationToken,
@@ -321,19 +354,11 @@ where
                                                         image.width, image.height, &image.data,
                                                     ) {
                                                         Ok(rgb_pixels) => {
-                                                            let mut comp = mozjpeg::Compress::new(
-                                                                mozjpeg::ColorSpace::JCS_RGB,
-                                                            );
-                                                            comp.set_size(
-                                                                image.width as usize,
-                                                                image.height as usize,
-                                                            );
-                                                            comp.set_fastest_defaults();
-
-                                                            let mut comp = comp.start_compress(Vec::new())?;
-                                                            comp.write_scanlines(&rgb_pixels)?;
-
-                                                            Ok(comp.finish()?)
+                                                            crate::source::decode_image::encode_rgb_to_jpeg(
+                                                                image.width as u32,
+                                                                image.height as u32,
+                                                                &rgb_pixels,
+                                                            )
                                                         }
                                                         Err(e) => {
                                                             eprintln!("failed to convert ARGB to RGB: {e}");
@@ -541,10 +566,13 @@ where
                 };
                 let html = match image_result {
                     Ok((image_bytes, ext, mime)) => {
-                        let filename = format!("images/img_{}.{}", index_image, ext);
-                        index_image += 1;
-
-                        epub.add_resource(&filename, Cursor::new(image_bytes), mime)?;
+                        let filename = store_epub_image_resource(
+                            &mut epub,
+                            &mut index_image,
+                            image_bytes,
+                            ext,
+                            mime,
+                        )?;
 
                         format!("<img src=\"../{}\"/>", filename)
                     }
@@ -563,14 +591,7 @@ where
                     }
                 }
 
-                epub.add_content(
-                    EpubContent::new(
-                        format!("pages/page_{}.xhtml", idx + 1),
-                        Cursor::new(create_xhtml(&title, &html)),
-                    )
-                    .title(title)
-                    .reftype(ReferenceType::Text),
-                )?;
+                add_epub_page(&mut epub, idx, title, &html)?;
             } else if let Some(text) = &page.text {
                 let document = Document::from(format!(
                     "<html><body>{}</body></html>",
@@ -589,10 +610,13 @@ where
                     };
                     match image_result {
                         Ok((image_bytes, ext, mime)) => {
-                            let filename = format!("images/img_{}.{}", index_image, ext);
-                            index_image += 1;
-
-                            epub.add_resource(&filename, Cursor::new(image_bytes), mime)?;
+                            let filename = store_epub_image_resource(
+                                &mut epub,
+                                &mut index_image,
+                                image_bytes,
+                                ext,
+                                mime,
+                            )?;
 
                             img.set_attr("src", &format!("../{}", filename));
                         }
@@ -601,34 +625,27 @@ where
 
                             let image_bytes =
                                 generate_error_image("Image error", &e.to_string(), 500, 667)?;
-
-                            let filename = format!("images/img_{}.{}", index_image, "jpeg");
-                            index_image += 1;
-
-                            epub.add_resource(&filename, Cursor::new(image_bytes), "image/jpeg")?;
+                            let filename = store_epub_image_resource(
+                                &mut epub,
+                                &mut index_image,
+                                &image_bytes,
+                                "jpeg",
+                                "image/jpeg",
+                            )?;
 
                             img.set_attr("src", &format!("../{}", filename));
                         }
                     }
                 }
 
-                let xhtml = create_xhtml(&title, document.select_single("body").html().as_ref());
-
-                epub.add_content(
-                    EpubContent::new(format!("pages/page_{}.xhtml", idx + 1), Cursor::new(xhtml))
-                        .title(title)
-                        .reftype(ReferenceType::Text),
-                )?;
+                let body_html = document.select_single("body").html();
+                add_epub_page(&mut epub, idx, title, body_html.as_ref())?;
             } else {
-                let html =
-                    "<p><strong>No content available for this page.</strong></p>".to_string();
-                epub.add_content(
-                    EpubContent::new(
-                        format!("pages/page_{}.xhtml", idx + 1),
-                        Cursor::new(create_xhtml(&title, &html)),
-                    )
-                    .title(title)
-                    .reftype(ReferenceType::Text),
+                add_epub_page(
+                    &mut epub,
+                    idx,
+                    title,
+                    "<p><strong>No content available for this page.</strong></p>",
                 )?;
             }
         }

--- a/backend/shared/src/chapter_downloader.rs
+++ b/backend/shared/src/chapter_downloader.rs
@@ -483,6 +483,9 @@ where
         .ok()
         .flatten();
 
+    #[cfg(not(feature = "all"))]
+    let on_progress_images = on_progress.clone();
+
     let images = download_all_images(
         chapter.url.as_ref(),
         &pages,
@@ -496,7 +499,7 @@ where
 
             if let Ok(mut stored) = stored_process_images.lock() {
                 stored.insert(idx, progress);
-                if let Some(ref cb) = on_progress {
+                if let Some(ref cb) = on_progress_images {
                     cb(stored.values().copied().sum(), total);
                 }
             }

--- a/backend/shared/src/chapter_storage.rs
+++ b/backend/shared/src/chapter_storage.rs
@@ -18,7 +18,7 @@ use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use reqwest::Request;
 
 use crate::model::{ChapterId, MangaId};
-use crate::source::decode_image::{decode_argb_to_rgb, decode_image_fast};
+use crate::source::decode_image::{decode_argb_to_rgb, decode_image_fast, encode_rgb_to_jpeg};
 
 const CHAPTER_FILE_EXTENSION: [&str; 2] = ["cbz", "epub"];
 
@@ -431,14 +431,7 @@ impl ChapterStorage {
             }
         };
 
-        let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
-        comp.set_size(width as usize, height as usize);
-        comp.set_fastest_defaults();
-
-        let mut comp = comp.start_compress(Vec::new())?;
-        comp.write_scanlines(&rgb_pixels)?;
-
-        Ok(comp.finish()?)
+        encode_rgb_to_jpeg(width, height, &rgb_pixels)
     }
 
     pub fn get_stored_chapter_and_errors(

--- a/backend/shared/src/database.rs
+++ b/backend/shared/src/database.rs
@@ -1495,7 +1495,12 @@ impl Database {
             builder.build().execute(&*self.pool.read().await).await?;
         }
 
-        const INSERT_FIELD_COUNT: usize = 8;
+        // Must match the column count in the `INSERT INTO chapter_informations`
+        // list below exactly: a stale, too-low value here makes `CHUNK_SIZE`
+        // too large, so a single chunk's bound parameter count
+        // (chunk_len * INSERT_FIELD_COUNT) can exceed SQLite's `BIND_LIMIT`
+        // and the whole insert silently fails for manga with many chapters.
+        const INSERT_FIELD_COUNT: usize = 12;
         const CHUNK_SIZE: usize = BIND_LIMIT / INSERT_FIELD_COUNT;
 
         for (offset, chunk) in chapter_informations.chunks(CHUNK_SIZE).enumerate() {
@@ -1533,7 +1538,8 @@ impl Database {
                 scanlator = excluded.scanlator,
                 chapter_number = excluded.chapter_number,
                 volume_number = excluded.volume_number,
-                last_updated = excluded.last_updated",
+                last_updated = excluded.last_updated,
+                lang = excluded.lang",
             );
 
             builder.build().execute(&*self.pool.read().await).await?;
@@ -3555,5 +3561,106 @@ impl From<NotificationInformationRow> for NotificationInformation {
             chapter_number: value.chapter_number.unwrap_or(-1.0),
             created_at: value.created_at,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn chapter_information(manga_id: &MangaId, chapter_id: &str, lang: &str) -> ChapterInformation {
+        ChapterInformation {
+            id: ChapterId::new(manga_id.clone(), chapter_id.to_string()),
+            title: Some(chapter_id.to_string()),
+            scanlator: Some("scanlator".to_string()),
+            chapter_number: None,
+            volume_number: None,
+            last_updated: None,
+            thumbnail: None,
+            lang: Some(lang.to_string()),
+            url: None,
+            locked: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn upsert_cached_chapter_informations_chunks_at_sqlite_bind_limit() {
+        let directory = tempdir().unwrap();
+        let database = Database::new(&directory.path().join("database.sqlite"))
+            .await
+            .unwrap();
+        let manga_id = MangaId::from_strings("source".to_string(), "manga".to_string());
+        let chapters = (0..(BIND_LIMIT / 12 + 1))
+            .map(|index| chapter_information(&manga_id, &index.to_string(), "en"))
+            .collect::<Vec<_>>();
+
+        database
+            .upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM chapter_informations WHERE source_id = ? AND manga_id = ?",
+        )
+        .bind(manga_id.source_id().value())
+        .bind(manga_id.value())
+        .fetch_one(&*database.pool.read().await)
+        .await
+        .unwrap();
+        assert_eq!(count, chapters.len() as i64);
+    }
+
+    #[tokio::test]
+    async fn upsert_cached_chapter_informations_refreshes_language() {
+        let directory = tempdir().unwrap();
+        let database = Database::new(&directory.path().join("database.sqlite"))
+            .await
+            .unwrap();
+        let manga_id = MangaId::from_strings("source".to_string(), "manga".to_string());
+
+        database
+            .upsert_cached_chapter_informations(
+                &manga_id,
+                &[chapter_information(&manga_id, "chapter", "en")],
+            )
+            .await
+            .unwrap();
+        database
+            .upsert_cached_chapter_informations(
+                &manga_id,
+                &[chapter_information(&manga_id, "chapter", "fr")],
+            )
+            .await
+            .unwrap();
+
+        let lang = sqlx::query_scalar::<_, Option<String>>(
+            "SELECT lang FROM chapter_informations WHERE source_id = ? AND manga_id = ? AND chapter_id = ?",
+        )
+        .bind(manga_id.source_id().value())
+        .bind(manga_id.value())
+        .bind("chapter")
+        .fetch_one(&*database.pool.read().await)
+        .await
+        .unwrap();
+        assert_eq!(lang.as_deref(), Some("fr"));
+
+        let mut chapter_without_language = chapter_information(&manga_id, "chapter", "fr");
+        chapter_without_language.lang = None;
+        database
+            .upsert_cached_chapter_informations(&manga_id, &[chapter_without_language])
+            .await
+            .unwrap();
+
+        let lang = sqlx::query_scalar::<_, Option<String>>(
+            "SELECT lang FROM chapter_informations WHERE source_id = ? AND manga_id = ? AND chapter_id = ?",
+        )
+        .bind(manga_id.source_id().value())
+        .bind(manga_id.value())
+        .bind("chapter")
+        .fetch_one(&*database.pool.read().await)
+        .await
+        .unwrap();
+        assert_eq!(lang, None);
     }
 }

--- a/backend/shared/src/source/decode_image.rs
+++ b/backend/shared/src/source/decode_image.rs
@@ -100,3 +100,15 @@ pub fn decode_argb_to_rgb(width: i32, height: i32, data: &[u32]) -> Result<Vec<u
 
     Ok(rgb_pixels)
 }
+
+/// Compress raw RGB8 pixel data into a JPEG using the fastest mozjpeg settings.
+pub fn encode_rgb_to_jpeg(width: u32, height: u32, rgb_pixels: &[u8]) -> Result<Vec<u8>> {
+    let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
+    comp.set_size(width as usize, height as usize);
+    comp.set_fastest_defaults();
+
+    let mut comp = comp.start_compress(Vec::new())?;
+    comp.write_scanlines(rgb_pixels)?;
+
+    Ok(comp.finish()?)
+}

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -1400,15 +1400,8 @@ impl BlockingSource {
                 let rgb_pixels = crate::source::decode_image::decode_argb_to_rgb(
                     width as i32, height as i32, &pixels,
                 )?;
-                let mut comp = mozjpeg::Compress::new(mozjpeg::ColorSpace::JCS_RGB);
-                comp.set_size(width as usize, height as usize);
-                comp.set_fastest_defaults();
 
-                let mut comp =  comp.start_compress(Vec::new())?;
-                comp.write_scanlines(&rgb_pixels)?;
-
-
-                comp.finish()?
+                crate::source::decode_image::encode_rgb_to_jpeg(width, height, &rgb_pixels)?
             };
 
             Ok(image_data)

--- a/backend/shared/src/source/wasm_imports/next/js.rs
+++ b/backend/shared/src/source/wasm_imports/next/js.rs
@@ -39,7 +39,8 @@ enum ResultContext {
     MissingResult,
     InvalidContext,
     InvalidString,
-    // InvalidRuleList,
+    #[cfg(not(feature = "all"))]
+    InvalidRuleList,
     // InvalidHandler,
     // InvalidRequest,
 }
@@ -53,7 +54,8 @@ impl From<ResultContext> for i32 {
             ResultContext::InvalidString => -3,
             // ResultContext::InvalidHandler => -4,
             // ResultContext::InvalidRequest => -5,
-            // ResultContext::InvalidRuleList => -6,
+            #[cfg(not(feature = "all"))]
+            ResultContext::InvalidRuleList => -6,
         }
     }
 }

--- a/backend/shared/src/usecases/fetch_manga_chapter.rs
+++ b/backend/shared/src/usecases/fetch_manga_chapter.rs
@@ -15,6 +15,7 @@ use crate::{
     source::Source,
 };
 
+/// Errors returned while fetching a manga chapter.
 pub use crate::chapter_downloader::Error;
 
 #[allow(clippy::too_many_arguments)]

--- a/backend/shared/src/usecases/fetch_manga_chapter.rs
+++ b/backend/shared/src/usecases/fetch_manga_chapter.rs
@@ -15,6 +15,8 @@ use crate::{
     source::Source,
 };
 
+pub use crate::chapter_downloader::Error;
+
 #[allow(clippy::too_many_arguments)]
 pub async fn fetch_manga_chapter(
     token: &CancellationToken,
@@ -57,7 +59,7 @@ pub async fn fetch_manga_chapter(
         Err(ChapterDownloaderError::Other(_))
             if use_ram && chapter_storage.tmpfs_full_storage().await? =>
         {
-            return ensure_chapter_is_in_storage(
+            ensure_chapter_is_in_storage(
                 token,
                 chapter_storage,
                 source,
@@ -71,20 +73,7 @@ pub async fn fetch_manga_chapter(
                 chapter_title_format,
             )
             .await
-            .map_err(|e| match e {
-                ChapterDownloaderError::Other(e) => Error::Other(e),
-                ChapterDownloaderError::DownloadError(e) => Error::DownloadError(e),
-            });
         }
-        Err(ChapterDownloaderError::DownloadError(e)) => Err(Error::DownloadError(e)),
-        Err(ChapterDownloaderError::Other(e)) => Err(Error::Other(e)),
+        result => result,
     }
-}
-
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
-    #[error("an error occurred while downloading the chapter pages")]
-    DownloadError(#[source] anyhow::Error),
-    #[error("unknown error")]
-    Other(#[from] anyhow::Error),
 }

--- a/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
+++ b/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
@@ -105,13 +105,30 @@ async fn apply_chapter_filter(
     filter: Filter,
     langs: &[&str],
 ) -> Result<Vec<ChapterInformation>> {
-    let mut last_read_chapter = None;
+    let mut last_read_chapter_num = None;
     let target_scanlator = match &filter {
         Filter::ScanlatorChapters { scanlator, .. } => Some(scanlator.clone()),
         _ => None,
     };
 
     let use_lang_filter = !langs.is_empty();
+
+    // Chapters are stored in source order (newest first). Use that order as a
+    // stable number for chapters whose source did not provide one, rather
+    // than making every such chapter number zero.
+    let total = all_chapters.len();
+    let effective_chapter_num = |chapter: &ChapterInformation, index: usize| {
+        chapter
+            .chapter_number
+            .unwrap_or((total.saturating_sub(1) - index) as f32)
+    };
+    let chapter_group = |chapter: &ChapterInformation, index: usize| {
+        chapter
+            .chapter_number
+            .map(ordered_float::OrderedFloat)
+            .map(ChapterGroup::Numbered)
+            .unwrap_or(ChapterGroup::Unnumbered(index))
+    };
 
     // Batch-fetch all chapter states for this manga in a single query
     let manga_id = all_chapters.first().map(|c| c.id.manga_id().clone());
@@ -122,7 +139,7 @@ async fn apply_chapter_filter(
     };
 
     // Starting from the newest chapter (in source order), find out the first one marked as read.
-    for chapter in all_chapters.iter() {
+    for (index, chapter) in all_chapters.iter().enumerate() {
         // Filter: language
         if use_lang_filter {
             let ch_lang = chapter.lang.as_deref().unwrap_or("unknown");
@@ -144,7 +161,7 @@ async fn apply_chapter_filter(
             .is_some_and(|state| state.read);
 
         if read {
-            last_read_chapter = Some(chapter.clone());
+            last_read_chapter_num = Some(effective_chapter_num(chapter, index));
 
             break;
         }
@@ -153,8 +170,9 @@ async fn apply_chapter_filter(
     // In reverse source order (oldest-to-newest), find out which unread chapters to download.
     let unread_chapters = all_chapters
         .into_iter()
+        .enumerate()
         .rev()
-        .filter(move |chapter| {
+        .filter(move |(_, chapter)| {
             if use_lang_filter {
                 let ch_lang = chapter.lang.as_deref().unwrap_or("unknown");
                 if !langs.contains(&ch_lang) {
@@ -163,38 +181,37 @@ async fn apply_chapter_filter(
             }
             true
         })
-        .skip_while(|chapter| {
-            last_read_chapter.as_ref().is_some_and(|last_read_chapter| {
-                last_read_chapter.chapter_number.unwrap_or_default()
-                    >= chapter.chapter_number.unwrap_or_default()
+        .skip_while(move |(index, chapter)| {
+            last_read_chapter_num.is_some_and(|last_read_chapter_num| {
+                last_read_chapter_num >= effective_chapter_num(chapter, *index)
             })
         });
 
     let filtered_chapters: Vec<_> = match filter {
-        Filter::AllUnreadChapters => unread_chapters.collect(),
+        Filter::AllUnreadChapters => unread_chapters.map(|(_, chapter)| chapter).collect(),
         Filter::NextUnreadChapters(amount) => {
             let mut seen_chapter_numbers = HashSet::new();
 
             unread_chapters
-                .take_while(|chapter| {
-                    seen_chapter_numbers.insert(ordered_float::OrderedFloat(
-                        chapter.chapter_number.unwrap_or_default(),
-                    ));
+                .take_while(|(index, chapter)| {
+                    seen_chapter_numbers.insert(chapter_group(chapter, *index));
 
                     seen_chapter_numbers.len() <= amount
                 })
+                .map(|(_, chapter)| chapter)
                 .collect()
         }
         Filter::ScanlatorChapters { scanlator, amount } => {
             // Filter by scanlator first
             let scanlator_chapters: Vec<_> = unread_chapters
-                .filter(|chapter| {
+                .filter(|(_, chapter)| {
                     chapter
                         .scanlator
                         .as_ref()
                         .map(|s| s == &scanlator)
                         .unwrap_or(scanlator == "Unknown")
                 })
+                .map(|(_, chapter)| chapter)
                 .collect();
 
             // Then limit by amount if specified
@@ -218,6 +235,12 @@ pub enum Filter {
     },
 }
 
+#[derive(Hash, Eq, PartialEq)]
+enum ChapterGroup {
+    Numbered(ordered_float::OrderedFloat<f32>),
+    Unnumbered(usize),
+}
+
 pub enum ProgressReport {
     Progressing { downloaded: usize, total: usize },
     Finished,
@@ -231,4 +254,124 @@ pub enum Error {
     DownloadError(#[source] anyhow::Error),
     #[error("unknown error")]
     Other(#[from] anyhow::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ChapterId, ChapterState};
+
+    fn chapter(manga_id: &MangaId, index: usize, number: Option<f32>) -> ChapterInformation {
+        ChapterInformation {
+            id: ChapterId::new(manga_id.clone(), format!("chapter-{index}")),
+            title: Some(format!("Chapter {index}")),
+            scanlator: None,
+            chapter_number: number,
+            volume_number: None,
+            last_updated: None,
+            thumbnail: None,
+            lang: None,
+            url: None,
+            locked: None,
+        }
+    }
+
+    async fn test_db() -> (tempfile::TempDir, Database, MangaId) {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let db = Database::new(&tmp_dir.path().join("test.db"))
+            .await
+            .unwrap();
+        let manga_id = MangaId::from_strings("test.source".to_owned(), "manga-1".to_owned());
+        (tmp_dir, db, manga_id)
+    }
+
+    #[tokio::test]
+    async fn all_un_numbered_chapters_stop_at_read_boundary() {
+        let (_tmp_dir, db, manga_id) = test_db().await;
+        let chapters: Vec<_> = (0..5).map(|i| chapter(&manga_id, i, None)).collect();
+        db.upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+        db.upsert_chapter_state(
+            &chapters[2].id,
+            ChapterState {
+                read: true,
+                last_read: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let chapters = db
+            .find_cached_chapter_informations(&manga_id)
+            .await
+            .unwrap();
+        let filtered = apply_chapter_filter(&db, chapters, Filter::AllUnreadChapters, &[])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|c| c.id.value().as_str())
+                .collect::<Vec<_>>(),
+            vec!["chapter-1", "chapter-0"]
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_numbered_and_unnumbered_chapters_keep_numbered_duplicates_grouped() {
+        let (_tmp_dir, db, manga_id) = test_db().await;
+        let chapters = vec![
+            chapter(&manga_id, 0, Some(3.0)),
+            chapter(&manga_id, 1, None),
+            chapter(&manga_id, 2, Some(2.0)),
+            chapter(&manga_id, 3, Some(2.0)),
+            chapter(&manga_id, 4, Some(1.0)),
+        ];
+        db.upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+
+        let chapters = db
+            .find_cached_chapter_informations(&manga_id)
+            .await
+            .unwrap();
+        let filtered = apply_chapter_filter(&db, chapters, Filter::NextUnreadChapters(2), &[])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|c| c.id.value().as_str())
+                .collect::<Vec<_>>(),
+            vec!["chapter-4", "chapter-3", "chapter-2"]
+        );
+    }
+
+    #[tokio::test]
+    async fn next_unread_chapters_respects_amount_for_unnumbered_chapters() {
+        let (_tmp_dir, db, manga_id) = test_db().await;
+        let chapters: Vec<_> = (0..6).map(|i| chapter(&manga_id, i, None)).collect();
+        db.upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+
+        let chapters = db
+            .find_cached_chapter_informations(&manga_id)
+            .await
+            .unwrap();
+        let filtered = apply_chapter_filter(&db, chapters, Filter::NextUnreadChapters(2), &[])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|c| c.id.value().as_str())
+                .collect::<Vec<_>>(),
+            vec!["chapter-5", "chapter-4"]
+        );
+    }
 }

--- a/frontend/rakuyomi.koplugin/BasicJobDialog.lua
+++ b/frontend/rakuyomi.koplugin/BasicJobDialog.lua
@@ -27,9 +27,8 @@ local BasicJobDialog = {
     success_message = nil,
     error_prefix = nil,
     format_progress = nil,
-    -- Current active widget (InfoMessage or ProgressbarDialog)
+    -- Current active widget (InfoMessage)
     widget = nil,
-    widget_type = nil, -- 'info' or 'progress'
     is_finished = false,
     errors = {},
 }
@@ -124,18 +123,14 @@ function BasicJobDialog:updateProgress()
     local state = self.job:poll()
 
     if state.type == 'PENDING' then
-        local data = state.body
-        local wants_progress = data and (data.total or data.progress_max)
-        local is_progress = self.widget_type == 'progress'
-
-        if not self.widget or (wants_progress and not is_progress) then
+        if not self.widget then
             if self.widget then
                 UIManager:close(self.widget)
             end
-            self:createWidget(data)
+            self:createWidget()
         end
 
-        self:updateWidget(data)
+        self:updateWidget(state.body)
 
         if not self.is_finished then
             UIManager:scheduleIn(1, self.updateProgress, self)
@@ -146,28 +141,15 @@ function BasicJobDialog:updateProgress()
     end
 end
 
-function BasicJobDialog:createWidget(data)
-    if data and (data.total or data.progress_max) then
-        local ProgressbarDialog = require("ui/widget/progressbardialog")
-        self.widget = ProgressbarDialog:new {
-            title = self.title or _("Processing..."),
-            progress_max = data.total or data.progress_max or 100,
-            on_cancel = function()
-                self:onCancellationRequested()
-            end
-        }
-        self.widget_type = 'progress'
-    else
-        self.widget = InfoMessage:new {
-            modal = false,
-            text = self.title or _("Processing..."),
-            dismissable = true,
-        }
-        overrideInfoMessageDismissHandler(self.widget, function()
-            self:onCancellationRequested()
-        end)
-        self.widget_type = 'info'
-    end
+function BasicJobDialog:createWidget()
+    self.widget = InfoMessage:new {
+        modal = false,
+        text = self.title or _("Processing..."),
+        dismissable = true,
+    }
+    overrideInfoMessageDismissHandler(self.widget, function()
+        self:onCancellationRequested()
+    end)
 
     UIManager:show(self.widget)
 end
@@ -187,13 +169,6 @@ function BasicJobDialog:updateWidget(data)
     if self.cancellation_requested then
         setWidgetText(self.widget, _("Waiting until cancelled…"))
         return
-    end
-
-    if data and data.current and self.widget.reportProgress then
-        self.widget:reportProgress(data.current)
-        if self.widget.redrawProgressbarIfNeeded then
-            self.widget:redrawProgressbarIfNeeded()
-        end
     end
 
     if data and data.errors then

--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -1288,13 +1288,11 @@ function LibraryView:startCleaner(modeInvalid)
       ),
       ok_text = _("Clean"),
       ok_callback = function()
-        local ProgressbarDialog = require("ui/widget/progressbardialog")
-
-        local progressbar_dialog = ProgressbarDialog:new {
-          title = _("Deleting..."),
-          progress_max = #filenames
+        local progress_message = InfoMessage:new {
+          text = _("Deleting..."),
+          dismissable = false,
         }
-        UIManager:show(progressbar_dialog)
+        UIManager:show(progress_message)
 
         for i, filename in ipairs(filenames) do
           local response_f = Backend.removeFile(filename)
@@ -1302,11 +1300,9 @@ function LibraryView:startCleaner(modeInvalid)
             ErrorDialog:show(response_f.message)
             return
           end
-          progressbar_dialog:reportProgress(i)
-          progressbar_dialog:redrawProgressbarIfNeeded()
         end
 
-        progressbar_dialog:close()
+        UIManager:close(progress_message)
 
         UIManager:show(InfoMessage:new {
           text = string.format(_("Cleaned free %s storage"), total_size)

--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -1294,7 +1294,7 @@ function LibraryView:startCleaner(modeInvalid)
         }
         UIManager:show(progress_message)
 
-        for i, filename in ipairs(filenames) do
+        for _, filename in ipairs(filenames) do
           local response_f = Backend.removeFile(filename)
           if response_f.type == 'ERROR' then
             ErrorDialog:show(response_f.message)

--- a/frontend/rakuyomi.koplugin/jobs/DownloadChapter.lua
+++ b/frontend/rakuyomi.koplugin/jobs/DownloadChapter.lua
@@ -52,7 +52,7 @@ function DownloadChapter:start()
     self.current_chapter_id
   )
   if response.type == 'ERROR' then
-    logger.error('could not create download chapter job', response.message)
+    logger.err('could not create download chapter job', response.message)
   else
     self.job_id = response.body
   end

--- a/frontend/rakuyomi.koplugin/jobs/DownloadScanlatorChapters.lua
+++ b/frontend/rakuyomi.koplugin/jobs/DownloadScanlatorChapters.lua
@@ -52,7 +52,7 @@ function DownloadScanlatorChapters:start()
   )
 
   if response.type == 'ERROR' then
-    logger.error('could not create download scanlator chapters job', response.message)
+    logger.err('could not create download scanlator chapters job', response.message)
     return false
   end
 

--- a/frontend/rakuyomi.koplugin/jobs/DownloadUnreadChapters.lua
+++ b/frontend/rakuyomi.koplugin/jobs/DownloadUnreadChapters.lua
@@ -66,7 +66,7 @@ function DownloadUnreadChapters:start()
   end
 
   if response.type == 'ERROR' then
-    logger.error('could not create download job', response.message)
+    logger.err('could not create download job', response.message)
 
     return false
   end

--- a/frontend/rakuyomi.koplugin/jobs/RefreshLibraryChapters.lua
+++ b/frontend/rakuyomi.koplugin/jobs/RefreshLibraryChapters.lua
@@ -24,7 +24,7 @@ end
 function RefreshLibraryChapters:start()
   local response = Backend.refreshLibraryChaptersJob()
   if response.type == 'ERROR' then
-    logger.error('could not create refresh library chapters job', response.message)
+    logger.err('could not create refresh library chapters job', response.message)
     return false
   else
     self.job_id = response.body

--- a/frontend/rakuyomi.koplugin/jobs/RefreshLibraryDetails.lua
+++ b/frontend/rakuyomi.koplugin/jobs/RefreshLibraryDetails.lua
@@ -24,7 +24,7 @@ end
 function RefreshLibraryDetails:start()
   local response = Backend.refreshLibraryDetailsJob()
   if response.type == 'ERROR' then
-    logger.error('could not create refresh library details job', response.message)
+    logger.err('could not create refresh library details job', response.message)
     return false
   else
     self.job_id = response.body


### PR DESCRIPTION
## Summary

Minimal generic bug fixes reconstructed from the iterative `upstream-fixes` history on this fork. Seven logical commits, one per fix category, each with a regression test where applicable.

**Note:** this branch was rebased/cleaned on 2026-08-15 to remove LNReader-specific commits that had leaked in via an earlier merge — the current history is 7 commits directly off `main`, containing only the fixes described below. Nothing was lost: the LNReader work lives entirely on the companion PR's branch (#293).

## Scope

Includes only — every commit has a passing regression test where applicable:

- **`fix(db): chunk chapter upserts by bind count`** — `INSERT_FIELD_COUNT` was stale (`8`) while the actual `INSERT INTO chapter_informations` list had grown to 12 columns, silently failing refresh for any manga with enough chapters to exceed SQLite's `BIND_LIMIT` (~2,730 chapters). Also refreshes `lang` on conflict, so chapters get a proper language on subsequent refreshes even if the first insert had `None`. Tests cover both the bind-limit chunk and `Some("en") → None` language clearing.
- **`fix(downloads): handle unnumbered batch chapters`** — `apply_chapter_filter` collapsed every unnumbered chapter's `chapter_number` to `0.0`, so once the user marked the first unread chapter, every remaining unread chapter compared `0.0 >= 0.0` and looked already-read — "download unread" silently downloaded nothing for any source with unnumbered chapters. The fix uses a positional surrogate derived from source order (oldest → `0`, newest → `total - 1`) for the read-boundary check, plus a `ChapterGroup` enum (Numbered/Unnumbered) for `NextUnreadChapters` deduplication so real duplicate chapter numbers across scanlators still group correctly.
- **`fix(build): restore non-default shared build`** — `cfg(not(feature = "all"))` clones the progress callback (it was moved into the image callback in the `all` path, leaving the non-`all` EPUB path with no progress). Also restores `cfg(not(feature = "all"))` on the `InvalidRuleList` `ResultContext` variant so the non-`all` build compiles cleanly.
- **`fix(api): propagate manga refresh failures`** — both `refresh_manga_chapters` and `refresh_manga_details` route handlers were discarding the `Result` with `let _ = ...`, returning `200 OK` even on failure. Replaced with `?` so errors surface to the caller.
- **`fix(koreader): use supported job feedback`** — `logger.err` (the real KOReader logger API) instead of `logger.error`, plus `InfoMessage` instead of the nonexistent `ui/widget/progressbardialog` in `BasicJobDialog.lua` and `LibraryView.lua`'s cleaner.
- **`refactor: deduplicate JPEG encoding, EPUB page helpers, and route boilerplate`** — extracts `encode_rgb_to_jpeg`, `add_epub_page`/`store_epub_image_resource`, `resolve_manga_covers`/`path_to_file_url`, and `read_read_tracking_settings` helpers to remove several copies of the same logic across `chapter_storage`, `chapter_downloader`, and the server routes. No behavior change.
- **`fix(api): preserve remote cover URL when no local poster exists`** — `resolve_manga_covers` unconditionally overwrote `manga.information.cover_url` with `poster_exists`'s result, clearing an existing remote `cover_url` to `None` for any manga without a downloaded local poster — non-base library, search, and playlist views lost their covers as a result. Now only overwrites `cover_url` when a local poster actually resolves to a file URL. Also documents two flagged public APIs per the repo's doc-comment guideline.

## Excluded

- **Source language discovery filtering** — a product behavior change (configured chapter languages now also determine which sources are discoverable) and base-subtag normalization is intentionally lossy. Worth a separate PR after confirming desired discovery semantics.
- **`MangaInfoWidget` layout / gesture series** — many iterative commits repeatedly changing and reverting wrappers, pan, padding, sizing, and stats height. Final behavior still relies on KOReader widget internals with no device/layout matrix validating it. Restart as a dedicated UI proposal if desired.
- **Formatted descriptions** — an HTML sanitizer path that was explicitly reverted by later commits in favor of plain `ScrollTextWidget`; resurrecting it would revive superseded code and a substantial security/maintenance surface.
- **Devenv/e2e work** — broad `nixpkgs`/`Aurora` lock churn and Poetry changes. Separate infrastructure PR if needed.
- **LNReader/JS source support** — the whole feature, entirely on the companion PR (#293). No overlap with this branch anymore.
- **Any reversal of upstream Android cookie or `math.floor` fixes** — both are present in `upstream/main` and must not be undone.

## Validation

- `cargo test --workspace`: **130 passed, 0 failed, 6 ignored**.
- `cargo build --workspace`: OK.
- `cargo clippy -p shared --lib -- -D warnings`: OK.
- `cargo fmt --all -- --check`: OK.

`cargo clippy --all-targets` is blocked by four pre-existing targets outside scope (`chapter_storage:777`, `arima_light:619`, `shikimori:270`, benchmark `chapter_downloader_benchmark`); these are not introduced or modified by this PR.

## Test plan on the reviewer's side

- `cargo test --workspace`.
- `cargo build --workspace`.
- `cargo fmt --all -- --check`.