### PR TITLE
Fix crash on tracking OAuth sign-in: Size.span.vertical_small does not exist

### DIFF
--- a/frontend/rakuyomi.koplugin/OAuthFlowView.lua
+++ b/frontend/rakuyomi.koplugin/OAuthFlowView.lua
@@ -119,7 +119,7 @@ function OAuthFlowView:init()
   }
   table.insert(widgets, self.status_widget)
 
-  table.insert(widgets, VerticalSpan:new { width = Size.span.vertical_small })
+  table.insert(widgets, VerticalSpan:new { width = Size.span.vertical_default })
 
   -- Manual check button
   table.insert(widgets, Button:new {


### PR DESCRIPTION
Fixes #294

`OAuthFlowView.lua` referenced `Size.span.vertical_small`, which doesn't
exist in KOReader's `frontend/ui/size.lua` (it only defines
`span.horizontal_default`, `horizontal_small`, `vertical_default`, and
`vertical_large`). In a debug build, reading a missing `Size` property
throws instead of returning `nil`, crashing the app the moment "Sign
in" is tapped for any tracking service, before the QR code screen ever
renders.

Changed to `Size.span.vertical_default`, the closest existing constant.

Tested on a Kindle Paperwhite 5, KOReader v2026.03 — "Sign in" now opens
the QR code screen correctly instead of crashing.