### PR TITLE
fix(tracking): include NSFW entries in MyAnimeList search

### DIFF
--- a/backend/shared/src/tracking/myanimelist.rs
+++ b/backend/shared/src/tracking/myanimelist.rs
@@ -55,6 +55,9 @@ impl Tracker for MalTracker {
         }
         let request = request.query(&[
             ("q", query),
+            // MAL hides NSFW entries from search by default unless the
+            // nsfw flag is explicitly enabled.
+            ("nsfw", "true"),
             ("limit", "5"),
             ("fields", "id,title,num_chapters,num_volumes"),
         ]);


### PR DESCRIPTION
Fixes #288

The MyAnimeList API hides NSFW entries from search results by default. This adds the `nsfw=true` query parameter to the manga search request so NSFW manga (e.g. Gushing Over Magical Girls) show up in the tracking search dialog.

- `backend/shared/src/tracking/myanimelist.rs`: pass `nsfw=true` in the MAL `/v2/manga` search query