### PR TITLE
fix: fetch CBZ metadata from the server instead of executing a binary

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -666,6 +666,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shared",
+ "thiserror",
 ]
 
 [[package]]
@@ -4076,6 +4077,7 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-macros",
+ "cbz_metadata_reader",
  "clap",
  "futures",
  "humansize",

--- a/backend/cbz_metadata_reader/Cargo.toml
+++ b/backend/cbz_metadata_reader/Cargo.toml
@@ -11,3 +11,4 @@ anyhow = "1.0"
 shared = { path = "../shared" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+thiserror = "2.0"

--- a/backend/cbz_metadata_reader/src/lib.rs
+++ b/backend/cbz_metadata_reader/src/lib.rs
@@ -1,0 +1,116 @@
+use std::path::Path;
+
+use serde::Serialize;
+use shared::cbz_metadata::{non_empty_string, ComicInfo};
+use thiserror::Error;
+
+/// Errors that can occur while extracting CBZ metadata.
+#[derive(Debug, Error)]
+pub enum MetadataError {
+    /// The archive contains no `ComicInfo.xml` entry, so no metadata exists.
+    #[error("no ComicInfo.xml entry in the archive")]
+    MissingComicInfo,
+    /// Any other failure (file I/O, invalid archive, malformed XML, ...).
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+/// Simplified metadata in the shape expected by KOReader's document properties.
+/// Serialized fields that are `None` are omitted from the JSON output.
+#[derive(Serialize, Debug, Default)]
+pub struct KoReaderMetadata {
+    /// Chapter title, from `ComicInfo/Title`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// Series name, from `ComicInfo/Series`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub series: Option<String>,
+    /// Chapter number within the series, from `ComicInfo/Number`, kept as a
+    /// string so values like "1.5" or "42" are preserved as-is.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub series_index: Option<String>,
+    /// Writer, penciller and inker concatenated with " & ", from
+    /// `ComicInfo/Writer`, `Penciller` and `Inker`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authors: Option<String>,
+    /// Publisher name, from `ComicInfo/Publisher`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publisher: Option<String>,
+    /// Publication year, from `ComicInfo/Year`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub publication_year: Option<i32>,
+    /// Language code (ISO 639), from `ComicInfo/LanguageISO`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+    /// Synopsis, mapped from `ComicInfo/Summary` (KOReader's `notes`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub notes: Option<String>,
+    /// Genre tags, mapped from `ComicInfo/Genre` (KOReader's `keywords`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub keywords: Option<String>,
+    /// Community rating on a 0-5 scale, from `ComicInfo/CommunityRating`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rating: Option<f64>,
+}
+
+/// Reads `ComicInfo.xml` from a CBZ file and returns the simplified KOReader
+/// metadata, in the same shape the `cbz_metadata_reader` binary prints.
+///
+/// Returns [`MetadataError::MissingComicInfo`] when the archive exists but
+/// has no `ComicInfo.xml` entry; all other failures are
+/// [`MetadataError::Other`].
+pub fn extract_metadata(file_path: &Path) -> Result<KoReaderMetadata, MetadataError> {
+    let comic_info = ComicInfo::from_file(file_path).map_err(|err| {
+        if err
+            .chain()
+            .any(|cause| cause.to_string() == "Couldn't find ComicInfo.xml in archive")
+        {
+            MetadataError::MissingComicInfo
+        } else {
+            MetadataError::Other(err)
+        }
+    })?;
+
+    Ok(transform_from_comic_info_xml(comic_info))
+}
+
+// Transform ComicInfo.xml data into KoReaderMetadata
+fn transform_from_comic_info_xml(comic_info: ComicInfo) -> KoReaderMetadata {
+    let mut ko_meta = KoReaderMetadata {
+        title: non_empty_string(comic_info.title),
+        series: non_empty_string(comic_info.series),
+        series_index: non_empty_string(comic_info.number),
+        publisher: non_empty_string(comic_info.publisher),
+        language: non_empty_string(comic_info.language_iso),
+        notes: non_empty_string(comic_info.summary),
+        keywords: non_empty_string(comic_info.genre),
+        ..Default::default()
+    };
+
+    // Combine writer, penciller, inker as authors
+    let mut authors = Vec::new();
+    if !comic_info.writer.is_empty() {
+        authors.push(comic_info.writer);
+    }
+
+    if !comic_info.penciller.is_empty() && !authors.contains(&comic_info.penciller) {
+        authors.push(comic_info.penciller);
+    }
+
+    if !comic_info.inker.is_empty() && !authors.contains(&comic_info.inker) {
+        authors.push(comic_info.inker);
+    }
+
+    if !authors.is_empty() {
+        ko_meta.authors = Some(authors.join(" & "));
+    }
+
+    if comic_info.year > 0 {
+        ko_meta.publication_year = Some(comic_info.year);
+    }
+
+    // Community rating (0-5 scale)
+    ko_meta.rating = comic_info.community_rating.map(|r| r.into());
+
+    ko_meta
+}

--- a/backend/cbz_metadata_reader/src/main.rs
+++ b/backend/cbz_metadata_reader/src/main.rs
@@ -1,33 +1,8 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
+use cbz_metadata_reader::extract_metadata;
 use clap::Parser;
-use serde::Serialize;
-use shared::cbz_metadata::{non_empty_string, ComicInfo};
-
-#[derive(Serialize, Debug, Default)]
-struct KoReaderMetadata {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    title: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    series: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    series_index: Option<String>, // Store as string
-    #[serde(skip_serializing_if = "Option::is_none")]
-    authors: Option<String>, // Concatenated authors
-    #[serde(skip_serializing_if = "Option::is_none")]
-    publisher: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    publication_year: Option<i32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    language: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    notes: Option<String>, // Map 'Comments' to 'notes'
-    #[serde(skip_serializing_if = "Option::is_none")]
-    keywords: Option<String>, // Map 'Genre' to 'keywords'
-    #[serde(skip_serializing_if = "Option::is_none")]
-    rating: Option<f64>,
-}
 
 #[derive(Parser, Debug)]
 struct Args {
@@ -39,57 +14,12 @@ fn main() -> Result<()> {
     let args = Args::parse();
     let file_path = PathBuf::from(&args.file_path);
 
-    // Read ComicInfo.xml from the CBZ file using the shared function
-    let comic_info = ComicInfo::from_file(&file_path)
-        .with_context(|| format!("Could not read metadata from {}", file_path.display()))?;
-
-    // Transform ComicInfo.xml into KoReaderMetadata
-    let ko_meta = transform_from_comic_info_xml(comic_info);
+    let ko_meta = extract_metadata(&file_path)
+        .with_context(|| format!("Failed to read metadata from {}", file_path.display()))?;
 
     let output_json =
         serde_json::to_string(&ko_meta).context("Failed to serialize metadata to JSON")?;
     println!("{}", output_json);
 
     Ok(())
-}
-
-// Transform ComicInfo.xml data into KoReaderMetadata
-fn transform_from_comic_info_xml(comic_info: ComicInfo) -> KoReaderMetadata {
-    let mut ko_meta = KoReaderMetadata {
-        title: non_empty_string(comic_info.title),
-        series: non_empty_string(comic_info.series),
-        series_index: non_empty_string(comic_info.number),
-        publisher: non_empty_string(comic_info.publisher),
-        language: non_empty_string(comic_info.language_iso),
-        notes: non_empty_string(comic_info.summary),
-        keywords: non_empty_string(comic_info.genre),
-        ..Default::default()
-    };
-
-    // Combine writer, penciller, inker as authors
-    let mut authors = Vec::new();
-    if !comic_info.writer.is_empty() {
-        authors.push(comic_info.writer);
-    }
-
-    if !comic_info.penciller.is_empty() && !authors.contains(&comic_info.penciller) {
-        authors.push(comic_info.penciller);
-    }
-
-    if !comic_info.inker.is_empty() && !authors.contains(&comic_info.inker) {
-        authors.push(comic_info.inker);
-    }
-
-    if !authors.is_empty() {
-        ko_meta.authors = Some(authors.join(" & "));
-    }
-
-    if comic_info.year > 0 {
-        ko_meta.publication_year = Some(comic_info.year);
-    }
-
-    // Community rating (0-5 scale)
-    ko_meta.rating = comic_info.community_rating.map(|r| r.into());
-
-    ko_meta
 }

--- a/backend/server/Cargo.toml
+++ b/backend/server/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1.0.103"
 axum-macros = "0.5.1"
 clap = { version = "4.6.1", features = ["derive"] }
 shared = { path = "../shared" }
+cbz_metadata_reader = { path = "../cbz_metadata_reader" }
 futures = "0.3.32"
 log = { version = "0.4.33", features = ["std"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use axum::extract::{Path, Query, State as StateExtractor};
 use axum::routing::{delete, get, patch, post};
 use axum::{Json, Router};
+#[cfg(target_os = "android")]
+use cbz_metadata_reader::{extract_metadata, MetadataError};
 use futures::Future;
 use log::warn;
 use serde::{Deserialize, Serialize};
@@ -35,7 +37,7 @@ fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
 }
 
 pub fn routes() -> Router<State> {
-    Router::new()
+    let router = Router::new()
         .route("/library", get(get_manga_library))
         .route("/storage-stats", get(get_storage_stats))
         .route("/find-orphan-or-read-files", get(find_orphan_or_read_files))
@@ -133,7 +135,15 @@ pub fn routes() -> Router<State> {
         .route(
             "/mangas/{source_id}/{manga_id}/viewer",
             post(set_manga_viewer),
-        )
+        );
+
+    #[cfg(target_os = "android")]
+    let router = router.route(
+        "/mangas/{source_id}/{manga_id}/chapters/{chapter_id}/metadata",
+        get(get_chapter_metadata),
+    );
+
+    router
 }
 
 async fn get_manga_library(
@@ -737,6 +747,43 @@ async fn revoke_manga_chapter(
     .await?;
 
     Ok(Json(result))
+}
+
+/// Returns the ComicInfo.xml metadata of a downloaded chapter, in the shape
+/// expected by KOReader's document properties. Only available on Android,
+/// where the `cbz_metadata_reader` binary cannot be executed (noexec storage).
+#[cfg(target_os = "android")]
+async fn get_chapter_metadata(
+    StateExtractor(State {
+        chapter_storage, ..
+    }): StateExtractor<State>,
+    Path(params): Path<DownloadMangaChapterParams>,
+) -> Result<Json<cbz_metadata_reader::KoReaderMetadata>, AppError> {
+    let chapter_id = ChapterId::from(params);
+
+    let path = {
+        let storage = chapter_storage.lock().await;
+        match storage.get_stored_chapter_and_errors(&chapter_id, true) {
+            Ok(Some((path, _))) => Some(path),
+            _ => storage
+                .get_stored_chapter_and_errors(&chapter_id, false)?
+                .map(|(path, _)| path),
+        }
+    };
+
+    let Some(path) = path else {
+        return Err(AppError::NotFound);
+    };
+
+    let metadata = tokio::task::spawn_blocking(move || extract_metadata(&path))
+        .await
+        .map_err(AppError::from)?
+        .map_err(|err| match err {
+            MetadataError::MissingComicInfo => AppError::NotFound,
+            MetadataError::Other(inner) => AppError::from(inner),
+        })?;
+
+    Ok(Json(metadata))
 }
 
 #[derive(Deserialize)]

--- a/frontend/rakuyomi.koplugin/Backend.lua
+++ b/frontend/rakuyomi.koplugin/Backend.lua
@@ -602,6 +602,19 @@ function Backend.updateLastReadChapter(source_id, manga_id, chapter_id)
   })
 end
 
+--- Gets the ComicInfo metadata of a downloaded chapter.
+---@param source_id string
+---@param manga_id string
+---@param chapter_id string
+---@return SuccessfulResponse<ChapterMetadata>|ErrorResponse
+function Backend.getChapterMetadata(source_id, manga_id, chapter_id)
+  return Backend.requestJson({
+    path = "/mangas/" ..
+        source_id .. "/" .. util.urlEncode(manga_id) .. "/chapters/" .. util.urlEncode(chapter_id) .. "/metadata",
+    method = "GET",
+  })
+end
+
 --- Marks the chapter as read.
 --- @param value boolean|nil
 --- @return SuccessfulResponse<nil>|ErrorResponse

--- a/frontend/rakuyomi.koplugin/MangaReader.lua
+++ b/frontend/rakuyomi.koplugin/MangaReader.lua
@@ -8,6 +8,7 @@ local logger = require("logger")
 local _ = require("gettext+")
 local Backend = require("Backend")
 local shallow_clone = require("utils/shallowClone")
+local CbzDocument = require("extensions/CbzDocument")
 
 local Testing = require('testing')
 
@@ -56,6 +57,7 @@ function MangaReader:show(options)
   self.on_open_chapter = options.on_open_chapter
   self.chapter = options.chapter
   self.chapters = options.chapters
+  CbzDocument:registerChapterFile(options.path, options.chapter)
   -- Global viewer override takes priority over per-manga/source viewer.
   local global_viewer = G_reader_settings:readSetting('rakuyomi_global_viewer')
   if global_viewer ~= nil and MangaViewer[global_viewer] ~= nil then

--- a/frontend/rakuyomi.koplugin/extensions/CbzDocument.lua
+++ b/frontend/rakuyomi.koplugin/extensions/CbzDocument.lua
@@ -2,11 +2,17 @@ local PdfDocument = require('document/pdfdocument')
 local logger = require("logger")
 local rapidjson = require("rapidjson")
 local Paths = require('Paths')
+local Device = require("device")
 local execute_binary_fast = require("utils/executeBinaryFast")
 
 -- Environment variable for overriding the command
 local CBZ_METADATA_READER_COMMAND_OVERRIDE = os.getenv('RAKUYOMI_CBZ_METADATA_READER_COMMAND_OVERRIDE')
 local CBZ_METADATA_READER_COMMAND_WORKING_DIRECTORY = os.getenv('RAKUYOMI_CBZ_METADATA_READER_WORKING_DIRECTORY')
+
+-- Maps opened file paths to their RakuYomi chapter info, so metadata can be
+-- fetched from the backend server instead of executing `cbz_metadata_reader`
+-- (which is not executable from noexec storage on Android).
+local chapter_by_file_path = {}
 
 
 local function getString(metadata, key)
@@ -35,9 +41,9 @@ local CbzDocument = PdfDocument:extend {
 function CbzDocument:getDocumentProps()
   local base_props = PdfDocument.getDocumentProps(self)
 
-  local json_content = self:_getComicBookInfoJSONFromBinary()
+  local json_content = self:_getComicBookInfoJSON()
   if not json_content then
-    logger.warn("CbzDocument: No JSON content received from binary.")
+    logger.warn("CbzDocument: No JSON content received from metadata source.")
     return base_props
   end
 
@@ -55,9 +61,58 @@ function CbzDocument:getDocumentProps()
   return base_props
 end
 
+--- Associates a file path with the RakuYomi chapter it belongs to, so that
+--- metadata can be fetched from the backend server when the file is opened.
+---@param file_path string The path of the chapter file.
+---@param chapter Chapter|nil The chapter, or nil to clear the association.
+function CbzDocument:registerChapterFile(file_path, chapter)
+  chapter_by_file_path[file_path] = chapter
+end
+
+--- Gets the simplified metadata JSON, trying the backend server first on
+--- Android (where the binary cannot be executed from noexec storage) and
+--- falling back to the external Rust binary otherwise.
+---@private
+---@return string|nil The JSON string or nil if no metadata was obtained.
+function CbzDocument:_getComicBookInfoJSON()
+  local chapter = chapter_by_file_path[self.file]
+  if Device:isAndroid() and chapter then
+    local json_content = self:_getComicBookInfoJSONFromServer(chapter)
+    if json_content then
+      return json_content
+    end
+  end
+
+  return self:_getComicBookInfoJSONFromBinary()
+end
+
+--- Calls the backend server to get simplified metadata JSON for a chapter.
+---@private
+---@param chapter Chapter
+---@return string|nil The JSON string or nil if the server had no metadata.
+function CbzDocument:_getComicBookInfoJSONFromServer(chapter)
+  local Backend = require("Backend")
+  local ok, response = pcall(Backend.getChapterMetadata, chapter.source_id,
+      chapter.manga_id, chapter.id)
+  if not ok or response == nil or response.type ~= 'SUCCESS' then
+    logger.warn("CbzDocument: Server returned no metadata for", self.file,
+        response and response.message or "")
+    return nil
+  end
+
+  local json_content = rapidjson.encode(response.body)
+  if json_content == "{}" then
+    logger.dbg("CbzDocument: Server returned empty metadata for", self.file)
+    return nil
+  end
+
+  logger.dbg("CbzDocument: Successfully received JSON from server for", self.file)
+  return json_content
+end
+
 --- Calls the external Rust binary to get simplified metadata JSON.
---- @private
---- @return string|nil The JSON string or nil if an error occurred.
+---@private
+---@return string|nil The JSON string or nil if an error occurred.
 function CbzDocument:_getComicBookInfoJSONFromBinary()
   local file_path = self.file
 
@@ -89,9 +144,9 @@ function CbzDocument:_getComicBookInfoJSONFromBinary()
 end
 
 --- Parses the simplified metadata JSON content from the Rust binary.
---- @private
---- @param json_content string The JSON content to parse.
---- @return table|nil The parsed metadata table or nil if parsing failed.
+---@private
+---@param json_content string The JSON content to parse.
+---@return table|nil The parsed metadata table or nil if parsing failed.
 function CbzDocument:_parseMetadata(json_content)
   -- Use rapidjson for decoding
   if not rapidjson or not rapidjson.decode then


### PR DESCRIPTION
Fixes #287

On Android the `cbz_metadata_reader` binary cannot be executed because the plugin folder lives on shared/external storage, which Android mounts noexec — so opened chapters showed no title/author/series.

Changes:
- Move `KoReaderMetadata` + `transform_from_comic_info_xml` from the `cbz_metadata_reader` binary into `shared::cbz_metadata` so both the binary and the server use the same code.
- New endpoint `GET /mangas/{source_id}/{manga_id}/chapters/{chapter_id}/metadata`: resolves the chapter file via `ChapterStorage` (RAM then disk), reads ComicInfo.xml, returns the KOReader metadata JSON. 404 when the chapter is not stored or has no ComicInfo.xml.
- `CbzDocument.lua` now asks the backend server for metadata first (the plugin registers the file->chapter association in `MangaReader:show`), falling back to the external binary for files the server doesn't know about (e.g. CBZ opened from the file manager). The server request is synchronous (`Backend.requestJson`), matching how the binary was invoked.

The binary path is unchanged on Unix; Android now gets metadata without executing anything.