### PR TITLE
fix(release): publish the per-ABI android plugin zips

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,6 +214,14 @@ jobs:
       with:
         path: build
         merge-multiple: true
+    - name: Combine android plugin zips
+      run: |
+        # The per-ABI android jobs all produce the same plugin zip (the
+        # libserver.so lives in the companion app, not in the plugin), so
+        # merge them back into a single rakuyomi-android.zip for release.
+        if compgen -G "build/rakuyomi-android-*.zip" > /dev/null; then
+          cp "$(ls build/rakuyomi-android-*.zip | head -1)" build/rakuyomi-android.zip
+        fi
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes missing Android asset on releases v1.40.0 and v1.40.1: PR #296 split the android build into parallel per-ABI jobs, so the packaged zips are now rakuyomi-android-armv7/aarch64/x86_64.zip while the release config still pointed at the old rakuyomi-android.zip.

The three per-ABI jobs all produce the identical plugin zip (libserver.so lives in the companion app, not the plugin), so the release job now combines them back into a single rakuyomi-android.zip and the release config entry is unchanged.