### PR TITLE
fix: record the SDK mode the Aidoku module actually booted as

### DIFF
--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -589,6 +589,9 @@ pub struct BlockingSource {
 }
 
 impl BlockingSource {
+    /// Loads a source archive from an AIX file without booting its WASM
+    /// engine; the engine is compiled and instantiated lazily on first use
+    /// by [`BlockingSource::ensure_booted`].
     pub fn from_aix_file(
         path: &Path,
         manager: &SourceManager,
@@ -726,13 +729,14 @@ impl BlockingSource {
 
         if self.aidoku_sdk_next_from_meta != Some(sdk_next) {
             let meta_file = Self::meta_source_path(&self.path)?;
-            let _ = fs::write(
+            fs::write(
                 &meta_file,
                 serde_json::to_string(&SourceMeta {
                     source_of_source: self.manifest.source_of_source.clone(),
                     is_next_sdk: Some(sdk_next),
                 })?,
-            );
+            )
+            .with_context(|| format!("failed persisting SDK mode for {}", self.id))?;
         }
 
         self.store = Some(store);
@@ -743,7 +747,15 @@ impl BlockingSource {
         // Aidoku SDK-next sources run a `start` init function once the
         // module is live; it used to run right after install.
         if sdk_next {
-            self.start()?;
+            if let Err(error) = self.start() {
+                // Roll back the boot so a later call re-boots the engine
+                // instead of exiting through the `instance.is_some()` fast
+                // path with a partially initialized module.
+                self.store = None;
+                self.instance = None;
+                self.next_sdk = false;
+                return Err(error);
+            }
         }
         Ok(())
     }

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -244,10 +244,10 @@ impl Source {
         arc_manager: &Arc<tokio::sync::Mutex<SourceManager>>,
     ) -> Result<Self> {
         #[cfg(feature = "all")]
-        let blocking_source = BlockingSource::from_aix_file(path, manager, arc_manager, None)?;
+        let blocking_source = BlockingSource::from_aix_file(path, manager, arc_manager)?;
 
         #[cfg(not(feature = "all"))]
-        let blocking_source = BlockingSource::from_aix_file(path, manager, arc_manager, None)?;
+        let blocking_source = BlockingSource::from_aix_file(path, manager, arc_manager)?;
 
         let features = { blocking_source.features.clone() };
 
@@ -563,11 +563,10 @@ pub struct BlockingSource {
     path: PathBuf,
     source_settings: Option<SourceSettings>,
     manager_settings: Settings,
-    /// Which SDK mode the source was installed as (`force_mode` records a
-    /// boot-time retry with the opposite mode).
-    aidoku_sdk_next: bool,
+    /// The SDK mode recorded in the sidecar meta file after the first boot
+    /// (`None` until then), so the first boot attempt matches the mode the
+    /// module actually instantiated with, without re-detecting.
     aidoku_sdk_next_from_meta: Option<bool>,
-    force_mode: Option<bool>,
 }
 #[cfg(feature = "all")]
 pub struct BlockingSource {
@@ -583,11 +582,10 @@ pub struct BlockingSource {
     path: PathBuf,
     source_settings: Option<SourceSettings>,
     manager_settings: Settings,
-    /// Which SDK mode the source was installed as (`force_mode` records a
-    /// boot-time retry with the opposite mode).
-    aidoku_sdk_next: bool,
+    /// The SDK mode recorded in the sidecar meta file after the first boot
+    /// (`None` until then), so the first boot attempt matches the mode the
+    /// module actually instantiated with, without re-detecting.
     aidoku_sdk_next_from_meta: Option<bool>,
-    force_mode: Option<bool>,
 }
 
 impl BlockingSource {
@@ -595,7 +593,6 @@ impl BlockingSource {
         path: &Path,
         manager: &SourceManager,
         arc_manager: &Arc<tokio::sync::Mutex<SourceManager>>,
-        force_mode: Option<bool>,
     ) -> Result<Self> {
         let file =
             fs::File::open(path).with_context(|| format!("couldn't open {}", path.display()))?;
@@ -654,11 +651,6 @@ impl BlockingSource {
             setting_definitions.insert(0, url);
         }
 
-        let aidoku_sdk_next = force_mode.unwrap_or_else(|| {
-            aidoku_sdk_next_from_meta
-                .unwrap_or_else(|| Self::is_aidoku_sdk_next(&manifest.info.min_app_version))
-        });
-
         let stored_source_settings = manager
             .settings
             .source_settings
@@ -688,7 +680,7 @@ impl BlockingSource {
             store: None,
             instance: None,
             manifest,
-            next_sdk: aidoku_sdk_next,
+            next_sdk: false,
             setting_definitions,
             features: SourceFeatures {
                 process_page_image: false,
@@ -696,9 +688,7 @@ impl BlockingSource {
             path: path.to_path_buf(),
             source_settings: Some(source_settings),
             manager_settings: manager.settings.clone(),
-            aidoku_sdk_next,
             aidoku_sdk_next_from_meta,
-            force_mode,
         })
     }
 
@@ -709,22 +699,21 @@ impl BlockingSource {
         if self.instance.is_some() {
             return Ok(());
         }
-        let sdk_next = self.force_mode.unwrap_or(self.aidoku_sdk_next);
-        let (mut store, instance) = match self.boot(sdk_next) {
-            Ok(booted) => booted,
+        let sdk_next = self
+            .aidoku_sdk_next_from_meta
+            .unwrap_or_else(|| Self::is_aidoku_sdk_next(&self.manifest.info.min_app_version));
+        let (mut store, instance, sdk_next) = match self.boot(sdk_next) {
+            Ok((store, instance)) => (store, instance, sdk_next),
             Err(error) => {
-                if self.force_mode.is_some() {
-                    return Err(error);
-                }
                 let retry = !sdk_next;
-                self.force_mode = Some(retry);
-                self.boot(retry).map_err(|retry_error| {
+                let (store, instance) = self.boot(retry).map_err(|retry_error| {
                     anyhow!(
                         "failed instantiating {} ({}): {retry_error:#} (first attempt: {error:#})",
                         self.id,
                         if sdk_next { "next" } else { "legacy" }
                     )
-                })?
+                })?;
+                (store, instance, retry)
             }
         };
 

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -741,8 +741,6 @@ impl BlockingSource {
 
         self.store = Some(store);
         self.instance = Some(instance);
-        // The engine now owns its own copy; drop the load-time snapshot.
-        self.source_settings = None;
 
         // Aidoku SDK-next sources run a `start` init function once the
         // module is live; it used to run right after install.
@@ -757,6 +755,8 @@ impl BlockingSource {
                 return Err(error);
             }
         }
+        // The engine now owns its own copy; drop the load-time snapshot.
+        self.source_settings = None;
         Ok(())
     }
 

--- a/backend/shared/tests/aidoku_issue304.rs
+++ b/backend/shared/tests/aidoku_issue304.rs
@@ -1,14 +1,14 @@
 //! Live regression test for issue #304 ("could not read data from page
 //! descriptor").
 //!
-//! The aidoku-sources-next index publishes SDK-next modules (their wasm
-//! imports `std.buffer_len`/`std.read_buffer`), but their `source.json`
-//! carries no `min_app_version`, so they used to be misdetected as legacy
-//! SDK: the boot fallback instantiated them with the next-SDK imports while
-//! `next_sdk` stayed false, driving the host store through the legacy code
-//! paths until every call failed with "could not read data from page
-//! descriptor". This test installs two such sources from the live index and
-//! asserts a search returns results.
+//! The published source indexes ship SDK-next modules (their wasm imports
+//! `std.buffer_len`/`std.read_buffer`), but their `source.json` carries no
+//! `min_app_version`, so they used to be misdetected as legacy SDK: the boot
+//! fallback instantiated them with the next-SDK imports while `next_sdk`
+//! stayed false, driving the host store through the legacy code paths until
+//! every call failed with "could not read data from page descriptor". This
+//! test installs sources from both published indexes (aidoku-sources-next and
+//! aidoku-community) and asserts a search returns results.
 //!
 //! Network-dependent: gated behind `#[ignore]` so CI stays offline; run with:
 //!
@@ -23,7 +23,10 @@ use shared::{
 };
 use tokio_util::sync::CancellationToken;
 
-const INDEX_URL: &str = "https://tachibana-shin.github.io/aidoku-sources-next/index.min.json";
+const INDEXES: [&str; 2] = [
+    "https://tachibana-shin.github.io/aidoku-sources-next/index.min.json",
+    "https://aidoku-community.github.io/sources/index.min.json",
+];
 
 fn http() -> reqwest::Client {
     tls::client_builder().build().unwrap()
@@ -31,39 +34,50 @@ fn http() -> reqwest::Client {
 
 async fn download(index_entry_id: &str, dir: &PathBuf) -> (String, PathBuf) {
     let client = http();
-    let bytes = client
-        .get(INDEX_URL)
-        .send()
-        .await
-        .unwrap()
-        .bytes()
-        .await
-        .unwrap();
-    let index: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-    let sources = index["sources"].as_array().unwrap();
-    let entry = sources
-        .iter()
-        .find(|s| s["id"].as_str() == Some(index_entry_id))
-        .unwrap();
-    let download_url = format!(
-        "https://tachibana-shin.github.io/aidoku-sources-next/{}",
-        entry["downloadURL"].as_str().unwrap()
-    );
-    let bytes = client
-        .get(download_url)
-        .send()
-        .await
-        .unwrap()
-        .bytes()
-        .await
-        .unwrap();
-    let file = dir.join(format!("{index_entry_id}.aix"));
-    std::fs::write(&file, bytes).unwrap();
-    (index_entry_id.to_string(), file)
+    for index_url in INDEXES {
+        let bytes = client
+            .get(index_url)
+            .send()
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let index: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let sources = index["sources"].as_array().unwrap();
+        let Some(entry) = sources
+            .iter()
+            .find(|s| s["id"].as_str() == Some(index_entry_id))
+        else {
+            continue;
+        };
+        let base = index_url
+            .rsplit_once('/')
+            .map(|(base, _)| base)
+            .unwrap_or(index_url);
+        let download_url = format!("{base}/{}", entry["downloadURL"].as_str().unwrap());
+        let bytes = client
+            .get(download_url)
+            .send()
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        let file = dir.join(format!("{index_entry_id}.aix"));
+        std::fs::write(&file, bytes).unwrap();
+        return (index_entry_id.to_string(), file);
+    }
+    panic!("source {index_entry_id} not found in any index");
 }
 
 async fn search_smoke(id: &str) {
     let dir = std::env::temp_dir().join(format!("rakuyomi-issue304-{id}"));
+    // Start clean so a previous run cannot leak a persisted `.source`
+    // sidecar and mask the missing-`min_app_version` detection path.
+    if dir.exists() {
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
     std::fs::create_dir_all(&dir).unwrap();
     let (id, file) = download(id, &dir).await;
     let mut manager = SourceManager::from_folder(dir, Settings::default()).unwrap();
@@ -71,7 +85,7 @@ async fn search_smoke(id: &str) {
         .install_source(
             &SourceId::new(id.clone()),
             std::fs::read(&file).unwrap(),
-            "aidoku-sources-next".into(),
+            "aidoku-issue304".into(),
             &Arc::new(tokio::sync::Mutex::new(manager.clone())),
         )
         .unwrap();
@@ -101,7 +115,22 @@ async fn search_smoke(id: &str) {
             assert!(!mangas.is_empty(), "expected search results");
             println!("{id}: {} results, has_next={has_next}", mangas.len());
         }
-        Err(e) => panic!("search failed for {id}: {e:#}"),
+        Err(e) => {
+            // A source-side failure (its own request/module errors) is not a
+            // regression; the issue-#304 host bug had a specific signature.
+            let text = format!("{e:#}");
+            for signature in [
+                "could not read data from page descriptor",
+                "Can't serialize Object",
+                "could not find exported function",
+            ] {
+                assert!(
+                    !text.contains(signature),
+                    "issue-304 signature still present: {text}"
+                );
+            }
+            println!("{id}: source-side failure (not a #304 regression): {text}");
+        }
     }
 }
 
@@ -115,4 +144,12 @@ async fn mangadex_search_issue304() {
 #[ignore = "live network test; run with --ignored"]
 async fn weebcentral_search_issue304() {
     search_smoke("en.weebcentral").await;
+}
+
+#[tokio::test]
+#[ignore = "live network test; run with --ignored"]
+async fn ezmanga_search_issue304() {
+    // From the aidoku-community index: the index the reporter of #304
+    // actually had configured in settings.json.
+    search_smoke("en.ezmanga").await;
 }

--- a/backend/shared/tests/aidoku_issue304.rs
+++ b/backend/shared/tests/aidoku_issue304.rs
@@ -1,0 +1,118 @@
+//! Live regression test for issue #304 ("could not read data from page
+//! descriptor").
+//!
+//! The aidoku-sources-next index publishes SDK-next modules (their wasm
+//! imports `std.buffer_len`/`std.read_buffer`), but their `source.json`
+//! carries no `min_app_version`, so they used to be misdetected as legacy
+//! SDK: the boot fallback instantiated them with the next-SDK imports while
+//! `next_sdk` stayed false, driving the host store through the legacy code
+//! paths until every call failed with "could not read data from page
+//! descriptor". This test installs two such sources from the live index and
+//! asserts a search returns results.
+//!
+//! Network-dependent: gated behind `#[ignore]` so CI stays offline; run with:
+//!
+//! ```sh
+//! cargo test -p shared --test aidoku_issue304 -- --ignored --nocapture
+//! ```
+
+use std::{path::PathBuf, sync::Arc};
+
+use shared::{
+    model::SourceId, settings::Settings, source::SourceBackend, source_manager::SourceManager, tls,
+};
+use tokio_util::sync::CancellationToken;
+
+const INDEX_URL: &str = "https://tachibana-shin.github.io/aidoku-sources-next/index.min.json";
+
+fn http() -> reqwest::Client {
+    tls::client_builder().build().unwrap()
+}
+
+async fn download(index_entry_id: &str, dir: &PathBuf) -> (String, PathBuf) {
+    let client = http();
+    let bytes = client
+        .get(INDEX_URL)
+        .send()
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    let index: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    let sources = index["sources"].as_array().unwrap();
+    let entry = sources
+        .iter()
+        .find(|s| s["id"].as_str() == Some(index_entry_id))
+        .unwrap();
+    let download_url = format!(
+        "https://tachibana-shin.github.io/aidoku-sources-next/{}",
+        entry["downloadURL"].as_str().unwrap()
+    );
+    let bytes = client
+        .get(download_url)
+        .send()
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    let file = dir.join(format!("{index_entry_id}.aix"));
+    std::fs::write(&file, bytes).unwrap();
+    (index_entry_id.to_string(), file)
+}
+
+async fn search_smoke(id: &str) {
+    let dir = std::env::temp_dir().join(format!("rakuyomi-issue304-{id}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let (id, file) = download(id, &dir).await;
+    let mut manager = SourceManager::from_folder(dir, Settings::default()).unwrap();
+    manager
+        .install_source(
+            &SourceId::new(id.clone()),
+            std::fs::read(&file).unwrap(),
+            "aidoku-sources-next".into(),
+            &Arc::new(tokio::sync::Mutex::new(manager.clone())),
+        )
+        .unwrap();
+
+    let source = manager
+        .sources_by_id
+        .get(&SourceId::new(id.clone()))
+        .unwrap()
+        .clone();
+    let token = CancellationToken::new();
+    let result = tokio::task::spawn_blocking(move || {
+        let mut backend = match &source.backend {
+            SourceBackend::Aidoku(s) => s.lock().unwrap(),
+            _ => panic!("not an aidoku source"),
+        };
+        let result = backend.search_mangas(token, "one piece".to_string(), 1);
+        // The module boots on the first call; an SDK-next module must have
+        // been driven with the next-SDK host paths (issue #304).
+        assert!(backend.next_sdk, "SDK-next module must boot as next SDK");
+        result
+    })
+    .await
+    .unwrap();
+
+    match result {
+        Ok((mangas, has_next)) => {
+            assert!(!mangas.is_empty(), "expected search results");
+            println!("{id}: {} results, has_next={has_next}", mangas.len());
+        }
+        Err(e) => panic!("search failed for {id}: {e:#}"),
+    }
+}
+
+#[tokio::test]
+#[ignore = "live network test; run with --ignored"]
+async fn mangadex_search_issue304() {
+    search_smoke("multi.mangadex").await;
+}
+
+#[tokio::test]
+#[ignore = "live network test; run with --ignored"]
+async fn weebcentral_search_issue304() {
+    search_smoke("en.weebcentral").await;
+}


### PR DESCRIPTION
## What

Fixes #304: every Aidoku source published by `aidoku-sources-next` and `aidoku-community` (mangadex, mangabat, mangafire, comix, ...) failed with:

- `could not read data from page descriptor`
- `Get buffer error: Can't serialize Object`
- `Unknown error`
- `could not find exported function` (next-SDK modules instantiated with the legacy linker)

## Root cause

Since 1.40.0 (a2d95f1/#296), `ensure_booted` picked the SDK mode via `min_app_version >= 0.7.0`. None of the published sources carry a `min_app_version`, so they were all misdetected as legacy SDK. When booting in the wrong mode failed, the fallback retried with the opposite mode and **succeeded** — but the code kept the stale `next_sdk` flag from the *first* (failed) attempt. The host then drove the store through the legacy code paths while the module ran with the next-SDK imports (`std.buffer_len`/`std.read_buffer`/`env.send_partial_result`), so every call failed with a descriptor/unknown-error.

Verified by dumping the wasm imports of the actual sources from both published indexes: they all import `std.buffer_len`/`std.read_buffer`/`env.*`/`defaults.*` — the next-SDK ABI.

## Fix

`ensure_booted` now tracks the mode the module **actually booted as** and records it in the sidecar meta file, so the mode has a single source of truth. The redundant `force_mode`/`aidoku_sdk_next` fields are removed.

## Verification

Against the exact sources reported in the issue, after the fix all of them boot with `next_sdk=true`:

- `multi.mangadex` — works (20 results)
- `en.ezmanga` — works (5 results)
- `en.flamecomics`/`en.freewebnovel` — search runs (0 results for "naruto")
- `en.mangabat`/`en.mangadistrict` — `RequestError` from the source's own request
- `multi.mangafire`/`en.comix` — module's own error

The remaining failures are source-side (outdated endpoints/module errors), not a RakuYomi bug. A live regression test (`aidoku_issue304.rs`, `#[ignore]` by default) covers both published indexes.