### PR TITLE
fix: rebuild focused backend fixes

### DIFF
--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -558,11 +558,7 @@ async fn refresh_manga_chapters(
 
     let token = create_token(cancel_token_store, cancel_id).await;
 
-    if let Err(e) =
-        usecases::refresh_manga_chapters(&token.0, &database, &source, &manga_id, 60).await
-    {
-        warn!("refresh_manga_chapters failed: {e:#}");
-    }
+    usecases::refresh_manga_chapters(&token.0, &database, &source, &manga_id, 60).await?;
 
     Ok(Json(()))
 }
@@ -611,15 +607,8 @@ async fn refresh_manga_details(
     let chapter_storage = &*chapter_storage.lock().await;
     let token = create_token(cancel_token_store, cancel_id).await;
 
-    let _ = usecases::refresh_manga_details(
-        &token.0,
-        &database,
-        chapter_storage,
-        &source,
-        &manga_id,
-        60,
-    )
-    .await;
+    usecases::refresh_manga_details(&token.0, &database, chapter_storage, &source, &manga_id, 60)
+        .await?;
 
     Ok(Json(()))
 }

--- a/backend/server/src/manga/routes.rs
+++ b/backend/server/src/manga/routes.rs
@@ -18,23 +18,10 @@ use shared::usecases;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
-use crate::model::{Chapter, Manga};
+use crate::model::{resolve_manga_covers, Chapter, Manga};
 use crate::source_extractor::SourceExtractor;
 use crate::state::State;
 use crate::AppError;
-
-fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
-    match url::Url::from_file_path(path) {
-        Ok(url) => Some(url),
-        Err(_) => match path.canonicalize() {
-            Ok(canonical_path) => url::Url::from_file_path(canonical_path).ok(),
-            Err(e) => {
-                println!("Error canonicalizing path: {}", e);
-                None
-            }
-        },
-    }
-}
 
 pub fn routes() -> Router<State> {
     let router = Router::new()
@@ -164,13 +151,7 @@ async fn get_manga_library(
         usecases::get_manga_library(&database, &*source_manager, library_sorting_mode).await?;
 
     if settings.library_view_mode != shared::settings::LibraryViewMode::Base {
-        for manga in mangas.iter_mut() {
-            if manga.information.cover_url.is_some() {
-                manga.information.cover_url = chapter_storage
-                    .poster_exists(&manga.information.id)
-                    .and_then(|path| path_to_file_url(&path));
-            }
-        }
+        resolve_manga_covers(&mut mangas, &chapter_storage);
     }
 
     Ok(Json(
@@ -349,13 +330,7 @@ async fn get_mangas(
         .map_err(AppError::from_search_mangas_error)?;
 
     if settings.search_view_mode != shared::settings::SearchViewMode::Base {
-        for manga in mangas.iter_mut() {
-            if manga.information.cover_url.is_some() {
-                manga.information.cover_url = chapter_storage
-                    .poster_exists(&manga.information.id)
-                    .and_then(|path| path_to_file_url(&path));
-            }
-        }
+        resolve_manga_covers(&mut mangas, &chapter_storage);
     }
 
     let results = mangas.into_iter().map(Manga::from).collect();

--- a/backend/server/src/model.rs
+++ b/backend/server/src/model.rs
@@ -1,12 +1,43 @@
 use serde::Serialize;
 
 use shared::{
+    chapter_storage::ChapterStorage,
     model::{
         Chapter as DomainChapter, Manga as DomainManga,
         SourceInformation as DomainSourceInformation,
     },
     source::model::MangaViewer,
 };
+
+/// Resolves each manga's cover to a local `file://` URL served from the
+/// chapter storage's downloaded poster, if one exists -- otherwise leaves the
+/// existing (typically remote) `cover_url` as-is, rather than clearing it.
+pub fn resolve_manga_covers(mangas: &mut [DomainManga], chapter_storage: &ChapterStorage) {
+    for manga in mangas.iter_mut() {
+        if let Some(local_cover_url) = chapter_storage
+            .poster_exists(&manga.information.id)
+            .and_then(|path| path_to_file_url(&path))
+        {
+            manga.information.cover_url = Some(local_cover_url);
+        }
+    }
+}
+
+/// Converts a local filesystem path into a `file://` URL, falling back to
+/// canonicalizing the path first if the direct conversion fails (e.g. for a
+/// relative path `Url::from_file_path` can't handle on its own).
+pub fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
+    match url::Url::from_file_path(path) {
+        Ok(url) => Some(url),
+        Err(_) => match path.canonicalize() {
+            Ok(canonical_path) => url::Url::from_file_path(canonical_path).ok(),
+            Err(e) => {
+                println!("Error canonicalizing path: {}", e);
+                None
+            }
+        },
+    }
+}
 
 #[derive(Serialize)]
 pub struct SourceInformation {

--- a/backend/server/src/model.rs
+++ b/backend/server/src/model.rs
@@ -32,7 +32,7 @@ pub fn path_to_file_url(path: &std::path::Path) -> Option<url::Url> {
         Err(_) => match path.canonicalize() {
             Ok(canonical_path) => url::Url::from_file_path(canonical_path).ok(),
             Err(e) => {
-                println!("Error canonicalizing path: {}", e);
+                log::warn!("Error canonicalizing path: {}", e);
                 None
             }
         },

--- a/backend/server/src/playlists/routes.rs
+++ b/backend/server/src/playlists/routes.rs
@@ -1,4 +1,4 @@
-use crate::model::Manga;
+use crate::model::{resolve_manga_covers, Manga};
 use axum::extract::{Path, State as StateExtractor};
 use axum::routing::{delete, get, post, put};
 use axum::{Json, Router};
@@ -93,25 +93,7 @@ async fn get_mangas_in_playlist(
     .await?;
 
     if settings.library_view_mode != shared::settings::LibraryViewMode::Base {
-        for manga in mangas.iter_mut() {
-            if manga.information.cover_url.is_some() {
-                manga.information.cover_url =
-                    if let Some(path) = chapter_storage.poster_exists(&manga.information.id) {
-                        match url::Url::from_file_path(&path) {
-                            Ok(url) => Some(url),
-                            Err(_) => match path.canonicalize() {
-                                Ok(canonical_path) => url::Url::from_file_path(canonical_path).ok(),
-                                Err(e) => {
-                                    println!("Error canonicalizing path: {}", e);
-                                    None
-                                }
-                            },
-                        }
-                    } else {
-                        None
-                    };
-            }
-        }
+        resolve_manga_covers(&mut mangas, &chapter_storage);
     }
 
     Ok(Json(

--- a/backend/shared/src/chapter_downloader.rs
+++ b/backend/shared/src/chapter_downloader.rs
@@ -556,6 +556,9 @@ where
         .ok()
         .flatten();
 
+    #[cfg(not(feature = "all"))]
+    let on_progress_images = on_progress.clone();
+
     let images = download_all_images(
         chapter.url.as_ref(),
         &pages,
@@ -569,7 +572,7 @@ where
 
             if let Ok(mut stored) = stored_process_images.lock() {
                 stored.insert(idx, progress);
-                if let Some(ref cb) = on_progress {
+                if let Some(ref cb) = on_progress_images {
                     cb(stored.values().copied().sum(), total);
                 }
             }

--- a/backend/shared/src/database.rs
+++ b/backend/shared/src/database.rs
@@ -1495,7 +1495,12 @@ impl Database {
             builder.build().execute(&*self.pool.read().await).await?;
         }
 
-        const INSERT_FIELD_COUNT: usize = 8;
+        // Must match the column count in the `INSERT INTO chapter_informations`
+        // list below exactly: a stale, too-low value here makes `CHUNK_SIZE`
+        // too large, so a single chunk's bound parameter count
+        // (chunk_len * INSERT_FIELD_COUNT) can exceed SQLite's `BIND_LIMIT`
+        // and the whole insert silently fails for manga with many chapters.
+        const INSERT_FIELD_COUNT: usize = 12;
         const CHUNK_SIZE: usize = BIND_LIMIT / INSERT_FIELD_COUNT;
 
         for (offset, chunk) in chapter_informations.chunks(CHUNK_SIZE).enumerate() {
@@ -1533,7 +1538,8 @@ impl Database {
                 scanlator = excluded.scanlator,
                 chapter_number = excluded.chapter_number,
                 volume_number = excluded.volume_number,
-                last_updated = excluded.last_updated",
+                last_updated = excluded.last_updated,
+                lang = excluded.lang",
             );
 
             builder.build().execute(&*self.pool.read().await).await?;
@@ -3555,5 +3561,106 @@ impl From<NotificationInformationRow> for NotificationInformation {
             chapter_number: value.chapter_number.unwrap_or(-1.0),
             created_at: value.created_at,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn chapter_information(manga_id: &MangaId, chapter_id: &str, lang: &str) -> ChapterInformation {
+        ChapterInformation {
+            id: ChapterId::new(manga_id.clone(), chapter_id.to_string()),
+            title: Some(chapter_id.to_string()),
+            scanlator: Some("scanlator".to_string()),
+            chapter_number: None,
+            volume_number: None,
+            last_updated: None,
+            thumbnail: None,
+            lang: Some(lang.to_string()),
+            url: None,
+            locked: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn upsert_cached_chapter_informations_chunks_at_sqlite_bind_limit() {
+        let directory = tempdir().unwrap();
+        let database = Database::new(&directory.path().join("database.sqlite"))
+            .await
+            .unwrap();
+        let manga_id = MangaId::from_strings("source".to_string(), "manga".to_string());
+        let chapters = (0..(BIND_LIMIT / 12 + 1))
+            .map(|index| chapter_information(&manga_id, &index.to_string(), "en"))
+            .collect::<Vec<_>>();
+
+        database
+            .upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM chapter_informations WHERE source_id = ? AND manga_id = ?",
+        )
+        .bind(manga_id.source_id().value())
+        .bind(manga_id.value())
+        .fetch_one(&*database.pool.read().await)
+        .await
+        .unwrap();
+        assert_eq!(count, chapters.len() as i64);
+    }
+
+    #[tokio::test]
+    async fn upsert_cached_chapter_informations_refreshes_language() {
+        let directory = tempdir().unwrap();
+        let database = Database::new(&directory.path().join("database.sqlite"))
+            .await
+            .unwrap();
+        let manga_id = MangaId::from_strings("source".to_string(), "manga".to_string());
+
+        database
+            .upsert_cached_chapter_informations(
+                &manga_id,
+                &[chapter_information(&manga_id, "chapter", "en")],
+            )
+            .await
+            .unwrap();
+        database
+            .upsert_cached_chapter_informations(
+                &manga_id,
+                &[chapter_information(&manga_id, "chapter", "fr")],
+            )
+            .await
+            .unwrap();
+
+        let lang = sqlx::query_scalar::<_, Option<String>>(
+            "SELECT lang FROM chapter_informations WHERE source_id = ? AND manga_id = ? AND chapter_id = ?",
+        )
+        .bind(manga_id.source_id().value())
+        .bind(manga_id.value())
+        .bind("chapter")
+        .fetch_one(&*database.pool.read().await)
+        .await
+        .unwrap();
+        assert_eq!(lang.as_deref(), Some("fr"));
+
+        let mut chapter_without_language = chapter_information(&manga_id, "chapter", "fr");
+        chapter_without_language.lang = None;
+        database
+            .upsert_cached_chapter_informations(&manga_id, &[chapter_without_language])
+            .await
+            .unwrap();
+
+        let lang = sqlx::query_scalar::<_, Option<String>>(
+            "SELECT lang FROM chapter_informations WHERE source_id = ? AND manga_id = ? AND chapter_id = ?",
+        )
+        .bind(manga_id.source_id().value())
+        .bind(manga_id.value())
+        .bind("chapter")
+        .fetch_one(&*database.pool.read().await)
+        .await
+        .unwrap();
+        assert_eq!(lang, None);
     }
 }

--- a/backend/shared/src/source/lnreader/manifest.rs
+++ b/backend/shared/src/source/lnreader/manifest.rs
@@ -111,6 +111,8 @@ pub fn manifest_from_props(
             id: props.id.clone(),
             lang: None,
             languages: None,
+            #[cfg(not(feature = "all"))]
+            content_rating: None,
             name: props.name.clone(),
             version: serde_json::Value::String(props.version.clone()),
             url: Some(props.site.clone()),

--- a/backend/shared/src/source/wasm_imports/next/js.rs
+++ b/backend/shared/src/source/wasm_imports/next/js.rs
@@ -38,7 +38,8 @@ enum ResultContext {
     MissingResult,
     InvalidContext,
     InvalidString,
-    // InvalidRuleList,
+    #[cfg(not(feature = "all"))]
+    InvalidRuleList,
     // InvalidHandler,
     // InvalidRequest,
 }
@@ -50,9 +51,10 @@ impl From<ResultContext> for i32 {
             ResultContext::MissingResult => -1,
             ResultContext::InvalidContext => -2,
             ResultContext::InvalidString => -3,
+            #[cfg(not(feature = "all"))]
+            ResultContext::InvalidRuleList => -6,
             // ResultContext::InvalidHandler => -4,
             // ResultContext::InvalidRequest => -5,
-            // ResultContext::InvalidRuleList => -6,
         }
     }
 }

--- a/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
+++ b/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
@@ -117,8 +117,6 @@ async fn apply_chapter_filter(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let total = all_chapters.len();
-
     // Assign each chapter an effective number for comparison: numbered
     // chapters use their actual chapter_number; unnumbered chapters use their
     // position in the sorted (oldest-to-newest) array so that every

--- a/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
+++ b/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
@@ -105,15 +105,16 @@ async fn apply_chapter_filter(
     filter: Filter,
     langs: &[&str],
 ) -> Result<Vec<ChapterInformation>> {
-    // Sort oldest-to-newest by chapter number so the position in the array is
-    // a stable, monotonic sequence regardless of numbering scheme. Unnumbered
-    // chapters (None → 0) sort to the front; slice::sort_by is stable so they
-    // keep their DB order relative to each other.
-    all_chapters.sort_by(|a, b| {
-        a.chapter_number
-            .unwrap_or_default()
-            .partial_cmp(&b.chapter_number.unwrap_or_default())
-            .unwrap_or(std::cmp::Ordering::Equal)
+    // Sort oldest-to-newest by chapter number so the sorted position is a
+    // stable, monotonic sequence. Unnumbered chapters (None) sort before
+    // every numbered chapter — including Some(0.0) — so they can never sit
+    // after a read chapter in the sorted order. slice::sort_by is stable,
+    // so equal-ranked unnumbered chapters keep their DB order.
+    all_chapters.sort_by(|a, b| match (&a.chapter_number, &b.chapter_number) {
+        (None, None) => std::cmp::Ordering::Equal,
+        (None, Some(_)) => std::cmp::Ordering::Less,
+        (Some(_), None) => std::cmp::Ordering::Greater,
+        (Some(a), Some(b)) => a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal),
     });
 
     let target_scanlator = match &filter {
@@ -412,6 +413,45 @@ mod tests {
         // Group keys:  Unnumbered(1), Numbered(1.0), Numbered(2.0), Numbered(2.0), Numbered(3.0).
         // amount=2 → groups {Unnumbered(1), Numbered(1.0)} → ch-1, ch-4.
         assert_eq!(ids(&filtered), vec!["chapter-1", "chapter-4"]);
+    }
+
+    #[tokio::test]
+    async fn unnumbered_chapter_not_selected_after_read_zero() {
+        let (_tmp_dir, db, manga_id) = test_db().await;
+        // DB order: ch-0(Some(0.0)), ch-1(None).  Without the fix the stable
+        // sort places them in DB order [Some(0.0), None], so marking ch-0
+        // read sets boundary=0 and ch-1(None) leaks through as "unread".
+        // With the fix, None sorts before Some(0.0) → sorted order becomes
+        // [ch-1(None), ch-0(Some(0.0))]; marking ch-0 read sets boundary=1,
+        // skipping both chapters.
+        let chapters = vec![
+            chapter(&manga_id, 0, Some(0.0)),
+            chapter(&manga_id, 1, None),
+        ];
+        db.upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+        db.upsert_chapter_state(
+            &chapters[0].id,
+            ChapterState {
+                read: true,
+                last_read: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let chapters = db
+            .find_cached_chapter_informations(&manga_id)
+            .await
+            .unwrap();
+        let filtered = apply_chapter_filter(&db, chapters, Filter::AllUnreadChapters, &[])
+            .await
+            .unwrap();
+
+        // Nothing should be returned — the unnumbered chapter sorts before
+        // the read Some(0.0) and is excluded by the boundary.
+        assert!(filtered.is_empty());
     }
 
     #[tokio::test]

--- a/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
+++ b/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
@@ -117,7 +117,36 @@ async fn apply_chapter_filter(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    let mut last_read_chapter = None;
+    let total = all_chapters.len();
+
+    // Assign each chapter an effective number for comparison: numbered
+    // chapters use their actual chapter_number; unnumbered chapters use their
+    // position in the sorted (oldest-to-newest) array so that every
+    // unnumbered chapter has a distinct, order-preserving value.
+    let effective_num = |chapter: &ChapterInformation, idx: usize| -> f32 {
+        chapter.chapter_number.unwrap_or(idx as f32)
+    };
+
+    // Group key for deduplication: numbered chapters with the same float
+    // value share one group, while each unnumbered chapter is its own group
+    // (identified by its sorted-array index).
+    let chapter_group = |chapter: &ChapterInformation, idx: usize| -> ChapterGroup {
+        chapter
+            .chapter_number
+            .map(ordered_float::OrderedFloat)
+            .map(ChapterGroup::Numbered)
+            .unwrap_or(ChapterGroup::Unnumbered(idx))
+    };
+
+    // Pre-compute effective numbers so they survive across the into_iter
+    // chain below.
+    let effective_nums: Vec<f32> = all_chapters
+        .iter()
+        .enumerate()
+        .map(|(i, ch)| effective_num(ch, i))
+        .collect();
+
+    let mut last_read_chapter_num = None;
     let target_scanlator = match &filter {
         Filter::ScanlatorChapters { scanlator, .. } => Some(scanlator.clone()),
         _ => None,
@@ -135,7 +164,7 @@ async fn apply_chapter_filter(
 
     // Starting from the newest chapter (the one with the highest chapter
     // number), find out the first one marked as read.
-    for chapter in all_chapters.iter().rev() {
+    for (index, chapter) in all_chapters.iter().enumerate().rev() {
         // Filter: language
         if use_lang_filter {
             let ch_lang = chapter.lang.as_deref().unwrap_or("unknown");
@@ -157,7 +186,7 @@ async fn apply_chapter_filter(
             .is_some_and(|state| state.read);
 
         if read {
-            last_read_chapter = Some(chapter.clone());
+            last_read_chapter_num = Some(effective_nums[index]);
 
             break;
         }
@@ -167,7 +196,8 @@ async fn apply_chapter_filter(
     // chapters to download.
     let unread_chapters = all_chapters
         .into_iter()
-        .filter(move |chapter| {
+        .enumerate()
+        .filter(move |(_, chapter)| {
             if use_lang_filter {
                 let ch_lang = chapter.lang.as_deref().unwrap_or("unknown");
                 if !langs.contains(&ch_lang) {
@@ -176,38 +206,36 @@ async fn apply_chapter_filter(
             }
             true
         })
-        .skip_while(|chapter| {
-            last_read_chapter.as_ref().is_some_and(|last_read_chapter| {
-                last_read_chapter.chapter_number.unwrap_or_default()
-                    >= chapter.chapter_number.unwrap_or_default()
-            })
+        .skip_while(move |(index, _)| {
+            last_read_chapter_num
+                .is_some_and(|last_read_num| last_read_num >= effective_nums[*index])
         });
 
     let filtered_chapters: Vec<_> = match filter {
-        Filter::AllUnreadChapters => unread_chapters.collect(),
+        Filter::AllUnreadChapters => unread_chapters.map(|(_, ch)| ch).collect(),
         Filter::NextUnreadChapters(amount) => {
-            let mut seen_chapter_numbers = HashSet::new();
+            let mut seen_groups = HashSet::new();
 
             unread_chapters
-                .take_while(|chapter| {
-                    seen_chapter_numbers.insert(ordered_float::OrderedFloat(
-                        chapter.chapter_number.unwrap_or_default(),
-                    ));
+                .take_while(|(index, chapter)| {
+                    seen_groups.insert(chapter_group(chapter, *index));
 
-                    seen_chapter_numbers.len() <= amount
+                    seen_groups.len() <= amount
                 })
+                .map(|(_, chapter)| chapter)
                 .collect()
         }
         Filter::ScanlatorChapters { scanlator, amount } => {
             // Filter by scanlator first
             let scanlator_chapters: Vec<_> = unread_chapters
-                .filter(|chapter| {
+                .filter(|(_, chapter)| {
                     chapter
                         .scanlator
                         .as_ref()
                         .map(|s| s == &scanlator)
                         .unwrap_or(scanlator == "Unknown")
                 })
+                .map(|(_, chapter)| chapter)
                 .collect();
 
             // Then limit by amount if specified
@@ -231,6 +259,12 @@ pub enum Filter {
     },
 }
 
+#[derive(Hash, Eq, PartialEq)]
+enum ChapterGroup {
+    Numbered(ordered_float::OrderedFloat<f32>),
+    Unnumbered(usize),
+}
+
 pub enum ProgressReport {
     Progressing { downloaded: usize, total: usize },
     Finished,
@@ -244,4 +278,132 @@ pub enum Error {
     DownloadError(#[source] anyhow::Error),
     #[error("unknown error")]
     Other(#[from] anyhow::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ChapterId, ChapterState};
+
+    fn chapter(manga_id: &MangaId, index: usize, number: Option<f32>) -> ChapterInformation {
+        ChapterInformation {
+            id: ChapterId::new(manga_id.clone(), format!("chapter-{index}")),
+            title: Some(format!("Chapter {index}")),
+            scanlator: None,
+            chapter_number: number,
+            volume_number: None,
+            last_updated: None,
+            thumbnail: None,
+            lang: None,
+            url: None,
+            locked: None,
+        }
+    }
+
+    async fn test_db() -> (tempfile::TempDir, Database, MangaId) {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let db = Database::new(&tmp_dir.path().join("test.db"))
+            .await
+            .unwrap();
+        let manga_id = MangaId::from_strings("test.source".to_owned(), "manga-1".to_owned());
+        (tmp_dir, db, manga_id)
+    }
+
+    #[tokio::test]
+    async fn all_un_numbered_chapters_stop_at_read_boundary() {
+        let (_tmp_dir, db, manga_id) = test_db().await;
+        let chapters: Vec<_> = (0..5).map(|i| chapter(&manga_id, i, None)).collect();
+        db.upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+        db.upsert_chapter_state(
+            &chapters[2].id,
+            ChapterState {
+                read: true,
+                last_read: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let chapters = db
+            .find_cached_chapter_informations(&manga_id)
+            .await
+            .unwrap();
+        let filtered = apply_chapter_filter(&db, chapters, Filter::AllUnreadChapters, &[])
+            .await
+            .unwrap();
+
+        // After sort (oldest-to-newest), chapter-2 (index 2) is the read
+        // boundary. Unread chapters newer than that are chapter-3 and chapter-4.
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|c| c.id.value().as_str())
+                .collect::<Vec<_>>(),
+            vec!["chapter-3", "chapter-4"]
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_numbered_and_unnumbered_chapters_keep_numbered_duplicates_grouped() {
+        let (_tmp_dir, db, manga_id) = test_db().await;
+        let chapters = vec![
+            chapter(&manga_id, 0, Some(3.0)),
+            chapter(&manga_id, 1, None),
+            chapter(&manga_id, 2, Some(2.0)),
+            chapter(&manga_id, 3, Some(2.0)),
+            chapter(&manga_id, 4, Some(1.0)),
+        ];
+        db.upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+
+        let chapters = db
+            .find_cached_chapter_informations(&manga_id)
+            .await
+            .unwrap();
+        let filtered = apply_chapter_filter(&db, chapters, Filter::NextUnreadChapters(2), &[])
+            .await
+            .unwrap();
+
+        // After sort (oldest-to-newest): ch-1(None,eff 0), ch-4(1.0),
+        // ch-2(2.0), ch-3(2.0), ch-0(3.0). NextUnreadChapters(2) takes the
+        // first 2 unique chapter-group keys: Unnumbered(0) and Numbered(1.0).
+        // Numbered duplicates (ch-2 and ch-3) share a key.
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|c| c.id.value().as_str())
+                .collect::<Vec<_>>(),
+            vec!["chapter-1", "chapter-4"]
+        );
+    }
+
+    #[tokio::test]
+    async fn next_unread_chapters_respects_amount_for_unnumbered_chapters() {
+        let (_tmp_dir, db, manga_id) = test_db().await;
+        let chapters: Vec<_> = (0..6).map(|i| chapter(&manga_id, i, None)).collect();
+        db.upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+
+        let chapters = db
+            .find_cached_chapter_informations(&manga_id)
+            .await
+            .unwrap();
+        let filtered = apply_chapter_filter(&db, chapters, Filter::NextUnreadChapters(2), &[])
+            .await
+            .unwrap();
+
+        // After sort (oldest-to-newest): ch-0(0), ch-1(1), ch-2(2), ...
+        // Each unnumbered chapter is its own group, so the first 2 are taken.
+        assert_eq!(
+            filtered
+                .iter()
+                .map(|c| c.id.value().as_str())
+                .collect::<Vec<_>>(),
+            vec!["chapter-0", "chapter-1"]
+        );
+    }
 }

--- a/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
+++ b/backend/shared/src/usecases/fetch_manga_chapters_in_batch.rs
@@ -105,11 +105,10 @@ async fn apply_chapter_filter(
     filter: Filter,
     langs: &[&str],
 ) -> Result<Vec<ChapterInformation>> {
-    // Do not rely on the DB order: databases created before the order
-    // normalization may still store chapters newest-first. Sort by chapter
-    // number so the filter logic below is correct regardless. Chapters
-    // without a parseable number fall back to 0 and keep their DB order as a
-    // tiebreaker (slice::sort_by is stable).
+    // Sort oldest-to-newest by chapter number so the position in the array is
+    // a stable, monotonic sequence regardless of numbering scheme. Unnumbered
+    // chapters (None → 0) sort to the front; slice::sort_by is stable so they
+    // keep their DB order relative to each other.
     all_chapters.sort_by(|a, b| {
         a.chapter_number
             .unwrap_or_default()
@@ -117,34 +116,6 @@ async fn apply_chapter_filter(
             .unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    // Assign each chapter an effective number for comparison: numbered
-    // chapters use their actual chapter_number; unnumbered chapters use their
-    // position in the sorted (oldest-to-newest) array so that every
-    // unnumbered chapter has a distinct, order-preserving value.
-    let effective_num = |chapter: &ChapterInformation, idx: usize| -> f32 {
-        chapter.chapter_number.unwrap_or(idx as f32)
-    };
-
-    // Group key for deduplication: numbered chapters with the same float
-    // value share one group, while each unnumbered chapter is its own group
-    // (identified by its sorted-array index).
-    let chapter_group = |chapter: &ChapterInformation, idx: usize| -> ChapterGroup {
-        chapter
-            .chapter_number
-            .map(ordered_float::OrderedFloat)
-            .map(ChapterGroup::Numbered)
-            .unwrap_or(ChapterGroup::Unnumbered(idx))
-    };
-
-    // Pre-compute effective numbers so they survive across the into_iter
-    // chain below.
-    let effective_nums: Vec<f32> = all_chapters
-        .iter()
-        .enumerate()
-        .map(|(i, ch)| effective_num(ch, i))
-        .collect();
-
-    let mut last_read_chapter_num = None;
     let target_scanlator = match &filter {
         Filter::ScanlatorChapters { scanlator, .. } => Some(scanlator.clone()),
         _ => None,
@@ -152,7 +123,7 @@ async fn apply_chapter_filter(
 
     let use_lang_filter = !langs.is_empty();
 
-    // Batch-fetch all chapter states for this manga in a single query
+    // Batch-fetch all chapter states for this manga in a single query.
     let manga_id = all_chapters.first().map(|c| c.id.manga_id().clone());
     let chapter_states = if let Some(id) = manga_id {
         db.find_chapter_states_for_manga(&id).await?
@@ -160,18 +131,17 @@ async fn apply_chapter_filter(
         HashMap::new()
     };
 
-    // Starting from the newest chapter (the one with the highest chapter
-    // number), find out the first one marked as read.
-    for (index, chapter) in all_chapters.iter().enumerate().rev() {
-        // Filter: language
+    // Walk newest-to-oldest (reverse of the sorted order) to locate the
+    // highest sorted index where a chapter is marked read. That index is the
+    // read boundary — everything at or before it is skipped.
+    let mut last_read_boundary: Option<usize> = None;
+    for (rev_idx, chapter) in all_chapters.iter().enumerate().rev() {
         if use_lang_filter {
             let ch_lang = chapter.lang.as_deref().unwrap_or("unknown");
             if !langs.contains(&ch_lang) {
                 continue;
             }
         }
-
-        // Skip chapters that don't match our target scanlator (if filtering by scanlator)
         if let Some(ref target_scanlator) = target_scanlator {
             let chapter_scanlator = chapter.scanlator.as_deref().unwrap_or("Unknown");
             if chapter_scanlator != target_scanlator {
@@ -179,23 +149,21 @@ async fn apply_chapter_filter(
             }
         }
 
-        let read = chapter_states
+        if chapter_states
             .get(chapter.id.value())
-            .is_some_and(|state| state.read);
-
-        if read {
-            last_read_chapter_num = Some(effective_nums[index]);
-
+            .is_some_and(|s| s.read)
+        {
+            last_read_boundary = Some(rev_idx);
             break;
         }
     }
 
-    // In oldest-to-newest order (by chapter number), find out which unread
-    // chapters to download.
-    let unread_chapters = all_chapters
+    // Collect unread chapters (oldest-to-newest), skipping everything at or
+    // before the read boundary index.
+    let unread_chapters: Vec<_> = all_chapters
         .into_iter()
         .enumerate()
-        .filter(move |(_, chapter)| {
+        .filter(|(_, chapter)| {
             if use_lang_filter {
                 let ch_lang = chapter.lang.as_deref().unwrap_or("unknown");
                 if !langs.contains(&ch_lang) {
@@ -204,28 +172,26 @@ async fn apply_chapter_filter(
             }
             true
         })
-        .skip_while(move |(index, _)| {
-            last_read_chapter_num
-                .is_some_and(|last_read_num| last_read_num >= effective_nums[*index])
-        });
+        .skip_while(move |(index, _)| last_read_boundary.is_some_and(|boundary| *index <= boundary))
+        .collect();
 
     let filtered_chapters: Vec<_> = match filter {
-        Filter::AllUnreadChapters => unread_chapters.map(|(_, ch)| ch).collect(),
+        Filter::AllUnreadChapters => unread_chapters.into_iter().map(|(_, ch)| ch).collect(),
         Filter::NextUnreadChapters(amount) => {
             let mut seen_groups = HashSet::new();
 
             unread_chapters
+                .into_iter()
                 .take_while(|(index, chapter)| {
                     seen_groups.insert(chapter_group(chapter, *index));
-
                     seen_groups.len() <= amount
                 })
                 .map(|(_, chapter)| chapter)
                 .collect()
         }
         Filter::ScanlatorChapters { scanlator, amount } => {
-            // Filter by scanlator first
             let scanlator_chapters: Vec<_> = unread_chapters
+                .into_iter()
                 .filter(|(_, chapter)| {
                     chapter
                         .scanlator
@@ -236,7 +202,6 @@ async fn apply_chapter_filter(
                 .map(|(_, chapter)| chapter)
                 .collect();
 
-            // Then limit by amount if specified
             if let Some(amount) = amount {
                 scanlator_chapters.into_iter().take(amount).collect()
             } else {
@@ -257,10 +222,21 @@ pub enum Filter {
     },
 }
 
+/// Grouping key for `NextUnreadChapters` deduplication: numbered chapters
+/// with the same value share one group; each unnumbered chapter is distinct
+/// (identified by its sorted-array index).
 #[derive(Hash, Eq, PartialEq)]
 enum ChapterGroup {
     Numbered(ordered_float::OrderedFloat<f32>),
     Unnumbered(usize),
+}
+
+fn chapter_group(chapter: &ChapterInformation, index: usize) -> ChapterGroup {
+    chapter
+        .chapter_number
+        .map(ordered_float::OrderedFloat)
+        .map(ChapterGroup::Numbered)
+        .unwrap_or(ChapterGroup::Unnumbered(index))
 }
 
 pub enum ProgressReport {
@@ -308,7 +284,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn all_un_numbered_chapters_stop_at_read_boundary() {
+    async fn all_unnumbered_chapters_stop_at_read_boundary() {
         let (_tmp_dir, db, manga_id) = test_db().await;
         let chapters: Vec<_> = (0..5).map(|i| chapter(&manga_id, i, None)).collect();
         db.upsert_cached_chapter_informations(&manga_id, &chapters)
@@ -332,19 +308,86 @@ mod tests {
             .await
             .unwrap();
 
-        // After sort (oldest-to-newest), chapter-2 (index 2) is the read
-        // boundary. Unread chapters newer than that are chapter-3 and chapter-4.
+        // Sorted oldest-to-newest: [ch-0, ch-1, ch-2(R), ch-3, ch-4].
+        // Boundary index 2; keep indices 3, 4.
+        assert_eq!(ids(&filtered), vec!["chapter-3", "chapter-4"]);
+    }
+
+    #[tokio::test]
+    async fn mixed_none_and_fractional_read_boundary() {
+        let (_tmp_dir, db, manga_id) = test_db().await;
+        // Created as: ch-0(None), ch-1(None), ch-2(Some(0.5)), ch-3(Some(1.0)).
+        // After sort (oldest-to-newest): [ch-0(None), ch-1(None), ch-2(0.5), ch-3(1.0)].
+        let chapters = vec![
+            chapter(&manga_id, 0, None),
+            chapter(&manga_id, 1, None),
+            chapter(&manga_id, 2, Some(0.5)),
+            chapter(&manga_id, 3, Some(1.0)),
+        ];
+        db.upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+        // Mark the fractional chapter (sorted index 2) as read.
+        db.upsert_chapter_state(
+            &chapters[2].id,
+            ChapterState {
+                read: true,
+                last_read: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let chapters = db
+            .find_cached_chapter_informations(&manga_id)
+            .await
+            .unwrap();
+        let filtered = apply_chapter_filter(&db, chapters, Filter::AllUnreadChapters, &[])
+            .await
+            .unwrap();
+
+        // Boundary index 2; only ch-3 (1.0) at index 3 is returned.
+        // Neither the read chapter nor the older unnumbered ones appear.
+        assert_eq!(ids(&filtered), vec!["chapter-3"]);
+    }
+
+    #[tokio::test]
+    async fn next_unread_chapters_amount_reaches_duplicate_numbered() {
+        let (_tmp_dir, db, manga_id) = test_db().await;
+        // ch-0(1.0), ch-1(1.0) duplicate, ch-2(2.0), ch-3(3.0).
+        // After sort: same order (1.0, 1.0, 2.0, 3.0).
+        let chapters = vec![
+            chapter(&manga_id, 0, Some(1.0)),
+            chapter(&manga_id, 1, Some(1.0)),
+            chapter(&manga_id, 2, Some(2.0)),
+            chapter(&manga_id, 3, Some(3.0)),
+        ];
+        db.upsert_cached_chapter_informations(&manga_id, &chapters)
+            .await
+            .unwrap();
+
+        let chapters = db
+            .find_cached_chapter_informations(&manga_id)
+            .await
+            .unwrap();
+        // amount=3 so the iterator passes through both duplicates (same group)
+        // and reaches ch-2 (second unique group) and ch-3 (third).
+        let filtered = apply_chapter_filter(&db, chapters, Filter::NextUnreadChapters(3), &[])
+            .await
+            .unwrap();
+
+        // First unique group: Numbered(1.0) → ch-0, ch-1.
+        // Second unique group: Numbered(2.0) → ch-2.
+        // Third unique group: Numbered(3.0) → ch-3.
+        // amount=3 keeps all four chapters.
         assert_eq!(
-            filtered
-                .iter()
-                .map(|c| c.id.value().as_str())
-                .collect::<Vec<_>>(),
-            vec!["chapter-3", "chapter-4"]
+            ids(&filtered),
+            vec!["chapter-0", "chapter-1", "chapter-2", "chapter-3"]
         );
     }
 
     #[tokio::test]
-    async fn mixed_numbered_and_unnumbered_chapters_keep_numbered_duplicates_grouped() {
+    async fn mixed_numbered_and_unnumbered_keep_numbered_duplicates_grouped() {
         let (_tmp_dir, db, manga_id) = test_db().await;
         let chapters = vec![
             chapter(&manga_id, 0, Some(3.0)),
@@ -365,21 +408,14 @@ mod tests {
             .await
             .unwrap();
 
-        // After sort (oldest-to-newest): ch-1(None,eff 0), ch-4(1.0),
-        // ch-2(2.0), ch-3(2.0), ch-0(3.0). NextUnreadChapters(2) takes the
-        // first 2 unique chapter-group keys: Unnumbered(0) and Numbered(1.0).
-        // Numbered duplicates (ch-2 and ch-3) share a key.
-        assert_eq!(
-            filtered
-                .iter()
-                .map(|c| c.id.value().as_str())
-                .collect::<Vec<_>>(),
-            vec!["chapter-1", "chapter-4"]
-        );
+        // Sort order: ch-1(None), ch-4(1.0), ch-2(2.0), ch-3(2.0), ch-0(3.0).
+        // Group keys:  Unnumbered(1), Numbered(1.0), Numbered(2.0), Numbered(2.0), Numbered(3.0).
+        // amount=2 → groups {Unnumbered(1), Numbered(1.0)} → ch-1, ch-4.
+        assert_eq!(ids(&filtered), vec!["chapter-1", "chapter-4"]);
     }
 
     #[tokio::test]
-    async fn next_unread_chapters_respects_amount_for_unnumbered_chapters() {
+    async fn next_unread_chapters_amount_for_unnumbered() {
         let (_tmp_dir, db, manga_id) = test_db().await;
         let chapters: Vec<_> = (0..6).map(|i| chapter(&manga_id, i, None)).collect();
         db.upsert_cached_chapter_informations(&manga_id, &chapters)
@@ -394,14 +430,11 @@ mod tests {
             .await
             .unwrap();
 
-        // After sort (oldest-to-newest): ch-0(0), ch-1(1), ch-2(2), ...
-        // Each unnumbered chapter is its own group, so the first 2 are taken.
-        assert_eq!(
-            filtered
-                .iter()
-                .map(|c| c.id.value().as_str())
-                .collect::<Vec<_>>(),
-            vec!["chapter-0", "chapter-1"]
-        );
+        // Each unnumbered chapter is its own group; first 2 are taken.
+        assert_eq!(ids(&filtered), vec!["chapter-0", "chapter-1"]);
+    }
+
+    fn ids(chapters: &[ChapterInformation]) -> Vec<&str> {
+        chapters.iter().map(|c| c.id.value().as_str()).collect()
     }
 }


### PR DESCRIPTION
## Summary

Rebuilds the focused backend fixes from #292 on current `main`. Frontend Lua changes are intentionally excluded.

## Fix mapping

| Fix | Replacement commits | Rebuilds #292 commits |
| --- | --- | --- |
| SQLite chapter upserts respect the bind limit and refresh `lang`. | `d658128` | `a7de7c8` |
| Batch downloads handle numbered and unnumbered chapters without crossing the read boundary. | `21ff311`, `a22e992`, `d0b6d33`, `fe0a70d` | `9b5d612` |
| The non-default shared build retains its progress callback and result mapping. | `ba76c92` | `f64080e` |
| Manga refresh endpoints return failures to clients. | `f895d7a` | `afc2e57` |
| Remote covers remain available when no local poster resolves; conversion failures use server logging. | `9752bea`, `9fcacfc` | `579a3d9` |

## Validation

- `cargo test --workspace`
- `cargo fmt --manifest-path backend/Cargo.toml --all -- --check`
- `cargo check -p server`

Supersedes #292.