### PR TITLE
feat/refactor: show source languages and pick languages when installing keiyoushi multi-source extensions (#312)

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1253,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "dexvm"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9806e335427c192de034f4802696349a16a884dc355373dc870e30d9f5bb91"
+checksum = "0dccdff0ef0cdb7f128236ba07551284ac679ae8c6206d0b2bec07a50d42ae9a"
 dependencies = [
  "aes 0.8.4",
  "aes-gcm",

--- a/backend/server/src/source/routes.rs
+++ b/backend/server/src/source/routes.rs
@@ -4,7 +4,7 @@ use axum::extract::{Path, State as StateExtractor};
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
-use shared::model::SourceId;
+use shared::model::{InstallOutcome, SourceId};
 use shared::resource_usage::SourceUsage;
 use shared::settings::SourceSettingValue;
 use shared::source::model::SettingDefinition;
@@ -58,6 +58,13 @@ struct InstallSourceParams {
     source_id: String,
 }
 
+#[derive(Deserialize)]
+struct InstallSourceRequest {
+    source_of_source: String,
+    #[serde(default)]
+    languages: Option<Vec<String>>,
+}
+
 async fn install_source(
     StateExtractor(State {
         source_manager,
@@ -65,18 +72,22 @@ async fn install_source(
         ..
     }): StateExtractor<State>,
     Path(InstallSourceParams { source_id }): Path<InstallSourceParams>,
-    Json(source_of_source): Json<String>,
-) -> Result<Json<()>, AppError> {
-    usecases::install_source(
+    Json(InstallSourceRequest {
+        source_of_source,
+        languages,
+    }): Json<InstallSourceRequest>,
+) -> Result<Json<InstallOutcome>, AppError> {
+    let outcome = usecases::install_source(
         &mut *source_manager.lock().await,
         &source_manager,
         &settings.lock().await.source_lists,
         SourceId::new(source_id),
         source_of_source,
+        languages,
     )
     .await?;
 
-    Ok(Json(()))
+    Ok(Json(outcome))
 }
 
 async fn list_installed_sources(

--- a/backend/shared/Cargo.toml
+++ b/backend/shared/Cargo.toml
@@ -88,7 +88,7 @@ ordered-float = "5.3.0"
 dom_query = { version = "0.28.0", features = ["atomic"] }
 d4rt_rs = "0.1.4"
 rquickjs = { version = "0.12.2", features = ["futures", "bindgen"] }
-dexvm = { version = "0.1.14", features = ["keiyoushi"] }
+dexvm = { version = "0.1.15", features = ["keiyoushi"] }
 zune-png = "0.5.2"
 zune-jpeg = "0.5.15"
 zune-core = "0.5.1"

--- a/backend/shared/src/model.rs
+++ b/backend/shared/src/model.rs
@@ -310,7 +310,12 @@ impl From<SourceManifest> for SourceInformation {
             id: SourceId::new(value.info.id),
             name: value.info.name,
             version: value.info.version,
-            languages: value.info.languages.unwrap_or_default(),
+            languages: value
+                .info
+                .languages
+                .filter(|langs| !langs.is_empty())
+                .or_else(|| value.info.lang.map(|lang| vec![lang]))
+                .unwrap_or_default(),
             source_of_source: value.source_of_source,
         }
     }
@@ -371,6 +376,20 @@ pub struct PlaylistManga {
     pub playlist_id: i64,
     pub source_id: String,
     pub manga_id: String,
+}
+
+/// The result of an install request. A multi-source keiyoushi APK asks the
+/// user which languages to install before anything is written to disk.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum InstallOutcome {
+    Installed,
+    SelectionRequired {
+        /// Display name of the extension, for the selection dialog title.
+        name: String,
+        /// Languages bundled in the APK, one entry per language.
+        languages: Vec<String>,
+    },
 }
 
 #[cfg(test)]
@@ -516,6 +535,30 @@ mod tests {
     }
 
     #[test]
+    fn test_source_information_from_manifest_falls_back_to_lang() {
+        // Keiyoushi and MangaYomi sources only set `lang` in the manifest;
+        // the reported languages must fall back to it.
+        let manifest = crate::source::SourceManifest {
+            info: crate::source::SourceInfo {
+                id: "test_id".to_string(),
+                lang: Some("vi".to_string()),
+                languages: None,
+                #[cfg(not(feature = "all"))]
+                content_rating: None,
+                name: "Test Source".to_string(),
+                version: serde_json::json!("1"),
+                url: None,
+                urls: None,
+                min_app_version: None,
+            },
+            config: None,
+            source_of_source: Some("test_sos".to_string()),
+        };
+        let info = SourceInformation::from(manifest);
+        assert_eq!(info.languages, vec!["vi".to_string()]);
+    }
+
+    #[test]
     fn test_source_information_deserializes_aidoku_languages() {
         let json =
             r#"{"id":"en.aquamanga","name":"Aqua Manga","version":1,"languages":["en","vi"]}"#;
@@ -550,6 +593,26 @@ mod tests {
         let json = r#"{"id":"en.royalroad","name":"Royal Road","version":"2.3.1"}"#;
         let info: SourceInformation = serde_json::from_str(json).unwrap();
         assert_eq!(info.version, serde_json::json!("2.3.1"));
+    }
+
+    #[test]
+    fn test_install_outcome_serializes_with_type_tag() {
+        assert_eq!(
+            serde_json::to_value(InstallOutcome::Installed).unwrap(),
+            serde_json::json!({ "type": "installed" })
+        );
+        assert_eq!(
+            serde_json::to_value(InstallOutcome::SelectionRequired {
+                name: "MangaDex".to_string(),
+                languages: vec!["en".to_string(), "vi".to_string()],
+            })
+            .unwrap(),
+            serde_json::json!({
+                "type": "selection_required",
+                "name": "MangaDex",
+                "languages": ["en", "vi"],
+            })
+        );
     }
 
     #[test]

--- a/backend/shared/src/source/keiyoushi/mod.rs
+++ b/backend/shared/src/source/keiyoushi/mod.rs
@@ -176,17 +176,17 @@ const DEFAULT_INVOKE_TIMEOUT: Duration = Duration::from_secs(60);
 /// The result of booting an extension APK once: the manifest package id,
 /// the sources it bundles and the preference definitions it materialises.
 #[derive(Serialize, Deserialize, Debug, Clone)]
-struct ApkProbe {
+pub struct ApkProbe {
     /// Canonical `manifest` package id (e.g.
     /// `eu.kanade.tachiyomi.extension.vi.cuutruyenmoe`).
-    package_id: String,
+    pub package_id: String,
     /// The `AndroidManifest` `versionName` (e.g. `1.6.8`), when declared.
     /// `serde(default)` keeps probe caches written before this field was
     /// introduced readable.
     #[serde(default)]
-    version_name: Option<String>,
-    sources: Vec<(String, String, bool)>,
-    setting_definitions: Vec<SettingDefinition>,
+    pub version_name: Option<String>,
+    pub sources: Vec<(String, String, bool)>,
+    pub setting_definitions: Vec<SettingDefinition>,
 }
 
 /// On-disk probe cache (`<pkg>.keiyoushi.probe.json`). The APK fingerprint
@@ -603,22 +603,30 @@ impl KeiyoushiSource {
             probe.package_id.clone()
         };
 
-        let source_of_source = {
+        // The meta file records where the extension was installed from and,
+        // for multi-source APKs, which bundled languages were selected at
+        // install time; a missing selection keeps every bundled source.
+        let (source_of_source, selected_languages) = {
             let meta_file = BlockingSource::meta_source_path(path)?;
-            let mut source_of_source = None;
             if meta_file.exists() {
                 let meta: SourceMeta = serde_json::from_str(
                     &fs::read_to_string(&meta_file)
                         .with_context(|| format!("failed to read meta file {:?}", meta_file))?,
                 )?;
-                source_of_source = meta.source_of_source;
+                (meta.source_of_source, meta.languages)
+            } else {
+                (None, None)
             }
-            source_of_source
         };
 
         let single = probe.sources.len() == 1;
         let mut out = Vec::with_capacity(probe.sources.len());
         for (index, (name, lang, supports_latest)) in probe.sources.iter().enumerate() {
+            if let Some(filter) = &selected_languages {
+                if !filter.iter().any(|selected| selected == lang) {
+                    continue;
+                }
+            }
             let id = if single {
                 pkg.to_string()
             } else {
@@ -1029,6 +1037,13 @@ fn probe_apk(bytes: &[u8]) -> Result<ApkProbe> {
         sources: out,
         setting_definitions: defs,
     })
+}
+
+/// Boots an extension APK once and returns the metadata shared by all of
+/// its bundled sources. Used by the install pipeline to decide whether a
+/// multi-source APK needs a language selection before being installed.
+pub fn probe_keiyoushi_apk(bytes: &[u8]) -> Result<ApkProbe> {
+    probe_apk(bytes)
 }
 
 /// Runs a coroutine-style (`getPopularManga` & friends) keiyoushi call,
@@ -1659,6 +1674,7 @@ mod tests {
                     fs::read(&fixture).unwrap(),
                     String::new(),
                     &arc_manager,
+                    None,
                 )
                 .unwrap();
             let apk_path = manager_guard.keiyoushi_source_path(&id);
@@ -1784,6 +1800,7 @@ mod tests {
                     fs::read(&fixture).unwrap(),
                     String::new(),
                     &arc_manager,
+                    None,
                 )
                 .unwrap();
             assert!(

--- a/backend/shared/src/source/keiyoushi/mod.rs
+++ b/backend/shared/src/source/keiyoushi/mod.rs
@@ -185,7 +185,10 @@ pub struct ApkProbe {
     /// introduced readable.
     #[serde(default)]
     pub version_name: Option<String>,
+    /// The `(name, lang, supports_latest)` triple of every source bundled
+    /// in the APK.
     pub sources: Vec<(String, String, bool)>,
+    /// Preference definitions materialised by the APK's sources.
     pub setting_definitions: Vec<SettingDefinition>,
 }
 

--- a/backend/shared/src/source/mod.rs
+++ b/backend/shared/src/source/mod.rs
@@ -349,12 +349,17 @@ impl Source {
         }
     }
 
-    pub fn write_meta_file(path: &Path, source_of_source: String) -> anyhow::Result<()> {
+    pub fn write_meta_file(
+        path: &Path,
+        source_of_source: String,
+        languages: Option<Vec<String>>,
+    ) -> anyhow::Result<()> {
         fs::write(
             BlockingSource::meta_source_path(path)?,
             serde_json::to_string(&SourceMeta {
                 source_of_source: Some(source_of_source),
                 is_next_sdk: None,
+                languages,
             })?,
         )
         .context("while writing meta file")
@@ -530,6 +535,10 @@ pub struct SourceMeta {
     #[serde(rename = "from")]
     pub source_of_source: Option<String>,
     pub is_next_sdk: Option<bool>,
+    /// The languages selected at install time for a multi-source keiyoushi
+    /// APK; `None` (or missing) keeps every bundled source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub languages: Option<Vec<String>>,
 }
 
 fn get_memory(instance: Instance, store: &mut Store<WasmStore>) -> Result<Memory> {
@@ -742,6 +751,7 @@ impl BlockingSource {
                 serde_json::to_string(&SourceMeta {
                     source_of_source: self.manifest.source_of_source.clone(),
                     is_next_sdk: Some(sdk_next),
+                    languages: None,
                 })?,
             );
         }

--- a/backend/shared/src/source_manager.rs
+++ b/backend/shared/src/source_manager.rs
@@ -175,6 +175,10 @@ impl SourceManager {
         arc_manager: &Arc<Mutex<SourceManager>>,
         languages: Option<&[String]>,
     ) -> Result<()> {
+        if languages.is_some_and(|langs| langs.is_empty()) {
+            bail!("keiyoushi language selection is empty");
+        }
+
         let target_path = self.keiyoushi_source_path(id);
         fs::write(&target_path, contents)?;
 
@@ -189,9 +193,13 @@ impl SourceManager {
         // the registered set would mix the old and the new selection.
         let doomed: Vec<SourceId> = self
             .sources_by_id
-            .keys()
-            .filter(|id2| self.keiyoushi_source_path(id2) == target_path)
-            .cloned()
+            .iter()
+            .filter_map(|(id, source)| match &source.backend {
+                SourceBackend::Keiyoushi(keiyoushi) => {
+                    (keiyoushi.apk_path() == target_path).then(|| id.clone())
+                }
+                _ => None,
+            })
             .collect();
         for doomed_id in doomed {
             self.sources_by_id.remove(&doomed_id);

--- a/backend/shared/src/source_manager.rs
+++ b/backend/shared/src/source_manager.rs
@@ -61,7 +61,7 @@ impl SourceManager {
         let target_path = self.source_path(id);
         fs::write(&target_path, contents)?;
 
-        Source::write_meta_file(&target_path, source_of_source)?;
+        Source::write_meta_file(&target_path, source_of_source, None)?;
 
         let source = Source::from_aix_file(&target_path, self, arc_manager)?;
         self.sources_by_id.insert(id.clone(), source);
@@ -85,7 +85,7 @@ impl SourceManager {
         let target_path = self.lnreader_source_path(id);
         fs::write(&target_path, contents)?;
 
-        Source::write_meta_file(&target_path, source_of_source)?;
+        Source::write_meta_file(&target_path, source_of_source, None)?;
 
         let source = Source::from_lnreader_file(&target_path, self, arc_manager)?;
         self.sources_by_id.insert(id.clone(), source);
@@ -148,7 +148,7 @@ impl SourceManager {
         fs::write(&target_path, code)?;
         fs::write(target_path.with_extension("json"), metadata.to_string())?;
 
-        Source::write_meta_file(&target_path, source_of_source)?;
+        Source::write_meta_file(&target_path, source_of_source, None)?;
 
         let source = Source::from_mangayomi_file(&target_path, self, arc_manager)?;
         self.sources_by_id.insert(id.clone(), source);
@@ -164,18 +164,40 @@ impl SourceManager {
     /// Installs a keiyoushi extension APK: the bytes are stored as
     /// `<pkg>.keiyoushi.apk` (one per extension package), and every source
     /// bundled in the APK is registered individually (see
-    /// [`Source::from_keiyoushi_file`]).
+    /// [`Source::from_keiyoushi_file`]). For a multi-source APK,
+    /// `languages` restricts which bundled sources are registered; the
+    /// selection is stored in the meta file so reloads keep it.
     pub fn install_keiyoushi_source(
         &mut self,
         id: &SourceId,
         contents: impl AsRef<[u8]>,
         source_of_source: String,
         arc_manager: &Arc<Mutex<SourceManager>>,
+        languages: Option<&[String]>,
     ) -> Result<()> {
         let target_path = self.keiyoushi_source_path(id);
         fs::write(&target_path, contents)?;
 
-        Source::write_meta_file(&target_path, source_of_source)?;
+        Source::write_meta_file(
+            &target_path,
+            source_of_source,
+            languages.map(|l| l.to_vec()),
+        )?;
+
+        // The selection in the meta file replaces any previous one, so drop
+        // the sources previously registered from this APK first; otherwise
+        // the registered set would mix the old and the new selection.
+        let doomed: Vec<SourceId> = self
+            .sources_by_id
+            .keys()
+            .filter(|id2| self.keiyoushi_source_path(id2) == target_path)
+            .cloned()
+            .collect();
+        for doomed_id in doomed {
+            self.sources_by_id.remove(&doomed_id);
+            #[cfg(not(feature = "all"))]
+            self.file_sources.remove(doomed_id.value());
+        }
 
         let sources = Source::from_keiyoushi_file(&target_path, self, arc_manager)?;
         for source in sources {

--- a/backend/shared/src/usecases/fetch_source_list.rs
+++ b/backend/shared/src/usecases/fetch_source_list.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
+use std::collections::HashMap;
 use url::Url;
 
 /// Fetches a source list index and returns its JSON form.
@@ -146,6 +147,26 @@ fn decode_repo_index(data: &[u8]) -> Result<Value> {
         }
     }
     Ok(Value::Array(entries))
+}
+
+/// Expands keiyoushi entry ids in place: the index publishes one entry per
+/// bundled source language, all sharing the extension package name, and a
+/// loaded multi-source APK registers its sources as `<pkg>:<lang>`. Entries
+/// of a package published with several languages therefore get
+/// `<pkg>:<lang>` ids (matching the sources an install produces), while
+/// single-language packages keep the plain package id.
+pub fn expand_keiyoushi_ids(entries: &mut [(String, Option<String>)]) {
+    let mut counts: HashMap<String, usize> = HashMap::new();
+    for (id, _) in entries.iter() {
+        *counts.entry(id.clone()).or_default() += 1;
+    }
+    for (id, lang) in entries.iter_mut() {
+        if counts.get(id.as_str()).copied().unwrap_or(0) > 1 {
+            if let Some(lang) = lang.clone() {
+                *id = format!("{id}:{lang}");
+            }
+        }
+    }
 }
 
 /// Decodes one `Extension` message into the JSON entries of the keiyoushi
@@ -537,5 +558,48 @@ mod tests {
         let entries = value.as_array().unwrap();
         assert_eq!(entries[0]["lang"], "all");
         assert_eq!(entries[0]["version"], "1.0.1");
+    }
+
+    #[test]
+    fn test_expand_keiyoushi_ids_multi_language_package() {
+        let mut entries = vec![
+            (
+                "eu.kanade.tachiyomi.extension.all.hentai3".to_string(),
+                Some("all".to_string()),
+            ),
+            (
+                "eu.kanade.tachiyomi.extension.all.hentai3".to_string(),
+                Some("en".to_string()),
+            ),
+            (
+                "eu.kanade.tachiyomi.extension.all.hentai3".to_string(),
+                Some("ja".to_string()),
+            ),
+            (
+                "eu.kanade.tachiyomi.extension.en.mangapill".to_string(),
+                Some("en".to_string()),
+            ),
+        ];
+        expand_keiyoushi_ids(&mut entries);
+        assert_eq!(
+            entries[0].0,
+            "eu.kanade.tachiyomi.extension.all.hentai3:all"
+        );
+        assert_eq!(entries[1].0, "eu.kanade.tachiyomi.extension.all.hentai3:en");
+        assert_eq!(entries[2].0, "eu.kanade.tachiyomi.extension.all.hentai3:ja");
+        // Single-language packages keep the plain package id.
+        assert_eq!(entries[3].0, "eu.kanade.tachiyomi.extension.en.mangapill");
+    }
+
+    #[test]
+    fn test_expand_keiyoushi_ids_keeps_entry_without_lang() {
+        let mut entries = vec![
+            ("some.pkg".to_string(), None),
+            ("some.pkg".to_string(), Some("en".to_string())),
+        ];
+        expand_keiyoushi_ids(&mut entries);
+        // No language to append: the id stays untouched.
+        assert_eq!(entries[0].0, "some.pkg");
+        assert_eq!(entries[1].0, "some.pkg:en");
     }
 }

--- a/backend/shared/src/usecases/install_source.rs
+++ b/backend/shared/src/usecases/install_source.rs
@@ -14,6 +14,15 @@ use crate::{
     usecases::resolve_source_list::{resolve_source_list, source_list_key},
 };
 
+/// Installs the source identified by `source_id` from the source list
+/// named by `source_of_source`.
+///
+/// For keiyoushi extensions, `languages` restricts which bundled sources
+/// of a multi-source APK get registered. Passing `None` for a multi-source
+/// APK installs nothing and returns
+/// [`InstallOutcome::SelectionRequired`] with the bundled languages so the
+/// caller can ask the user for a selection; a non-empty selection must
+/// only contain languages the APK actually bundles.
 pub async fn install_source(
     source_manager: &mut SourceManager,
     arc_manager: &Arc<Mutex<SourceManager>>,
@@ -152,6 +161,23 @@ pub async fn install_source(
                     None,
                 )?;
             } else if let Some(languages) = languages {
+                let bundled = probe
+                    .sources
+                    .iter()
+                    .map(|(_, lang, _)| lang.as_str())
+                    .collect::<std::collections::HashSet<_>>();
+                if languages.is_empty() {
+                    anyhow::bail!("keiyoushi language selection is empty");
+                }
+                if let Some(unknown) = languages
+                    .iter()
+                    .find(|lang| !bundled.contains(lang.as_str()))
+                {
+                    anyhow::bail!(
+                        "keiyoushi extension does not bundle the selected language '{unknown}'"
+                    );
+                }
+
                 source_manager.install_keiyoushi_source(
                     &source_id,
                     apk_content,

--- a/backend/shared/src/usecases/install_source.rs
+++ b/backend/shared/src/usecases/install_source.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use crate::{
-    model::SourceId,
+    model::{InstallOutcome, SourceId},
     settings::SourceList,
     source_manager::SourceManager,
     usecases::fetch_source_list::fetch_source_list,
@@ -20,7 +20,8 @@ pub async fn install_source(
     source_lists: &[SourceList],
     source_id: SourceId,
     source_of_source: String,
-) -> Result<()> {
+    languages: Option<Vec<String>>,
+) -> Result<InstallOutcome> {
     let (source_list, source_list_item, source_of_source) = stream::iter(
         source_lists
             .iter()
@@ -36,7 +37,7 @@ pub async fn install_source(
         let value = fetch_source_list(&client, &resolved_list).await?;
 
         // Try both formats
-        let source_list_items = if value.is_array() {
+        let mut source_list_items = if value.is_array() {
             serde_json::from_value::<Vec<SourceListItem>>(value)?
         } else if let Some(arr) = value.get("sources").and_then(|v| v.as_array()) {
             serde_json::from_value::<Vec<SourceListItem>>(Value::Array(arr.clone()))?
@@ -47,6 +48,29 @@ pub async fn install_source(
                 value
             );
         };
+
+        // Match the id expansion `list_available_sources` applies: entries
+        // of a keiyoushi package published with several languages are named
+        // `<pkg>:<lang>`.
+        if source_list.source_type == crate::settings::SourceListType::Keiyoushi {
+            let mut entries = source_list_items
+                .iter()
+                .map(|item| {
+                    (
+                        item.id.value().to_string(),
+                        item.item
+                            .get("lang")
+                            .and_then(|lang| lang.as_str())
+                            .map(String::from),
+                    )
+                })
+                .collect::<Vec<_>>();
+            crate::usecases::fetch_source_list::expand_keiyoushi_ids(&mut entries);
+            for (item, (id, _)) in source_list_items.iter_mut().zip(entries) {
+                item.id = SourceId::new(id);
+            }
+        }
+
         anyhow::Ok((source_list, source_list_items, key))
     })
     .try_collect::<Vec<_>>()
@@ -114,12 +138,47 @@ pub async fn install_source(
                 .file
                 .context("Keiyoushi source list item is missing an `apk` URL")?;
             let apk_content = client.get(apk_url).send().await?.bytes().await?;
-            source_manager.install_keiyoushi_source(
-                &source_id,
-                apk_content,
-                source_of_source,
-                arc_manager,
-            )?;
+
+            // A keiyoushi APK bundles one source per language; installing a
+            // multi-source APK without a selection would register every
+            // language, so it first asks which languages to install.
+            let probe = crate::source::keiyoushi::probe_keiyoushi_apk(&apk_content)?;
+            if probe.sources.len() == 1 {
+                source_manager.install_keiyoushi_source(
+                    &source_id,
+                    apk_content,
+                    source_of_source,
+                    arc_manager,
+                    None,
+                )?;
+            } else if let Some(languages) = languages {
+                source_manager.install_keiyoushi_source(
+                    &source_id,
+                    apk_content,
+                    source_of_source,
+                    arc_manager,
+                    Some(&languages),
+                )?;
+            } else {
+                let mut bundled_languages = probe
+                    .sources
+                    .iter()
+                    .map(|(_, lang, _)| lang.clone())
+                    .collect::<Vec<_>>();
+                bundled_languages.sort();
+                bundled_languages.dedup();
+                let name = source_list_item
+                    .item
+                    .get("name")
+                    .and_then(|name| name.as_str())
+                    .unwrap_or(source_id.value())
+                    .to_string();
+
+                return Ok(InstallOutcome::SelectionRequired {
+                    name,
+                    languages: bundled_languages,
+                });
+            }
         }
         crate::settings::SourceListType::Aidoku => {
             let file = source_list_item
@@ -141,7 +200,7 @@ pub async fn install_source(
         }
     }
 
-    Ok(())
+    Ok(InstallOutcome::Installed)
 }
 
 #[derive(Deserialize)]

--- a/backend/shared/src/usecases/list_available_sources.rs
+++ b/backend/shared/src/usecases/list_available_sources.rs
@@ -39,6 +39,21 @@ pub async fn list_available_sources(
                 src.source_of_source = Some(key.clone());
             }
 
+            // Keiyoushi publishes one entry per bundled source language
+            // under the same package id; multi-source extensions get
+            // `<pkg>:<lang>` ids so entries match the sources installing
+            // them produces.
+            if source_list.source_type == crate::settings::SourceListType::Keiyoushi {
+                let mut entries = sources
+                    .iter()
+                    .map(|src| (src.id.value().to_string(), src.languages.first().cloned()))
+                    .collect::<Vec<_>>();
+                crate::usecases::fetch_source_list::expand_keiyoushi_ids(&mut entries);
+                for (src, (id, _)) in sources.iter_mut().zip(entries) {
+                    src.id = crate::model::SourceId::new(id);
+                }
+            }
+
             Ok(sources)
         })
         .try_collect::<Vec<_>>()

--- a/backend/shared/tests/keiyoushi_fetch_live.rs
+++ b/backend/shared/tests/keiyoushi_fetch_live.rs
@@ -46,6 +46,7 @@ fn probe_fetch_page_image() {
             bytes,
             "keiyoushi/extensions".to_string(),
             &manager,
+            None,
         )
         .unwrap_or_else(|e| panic!("install failed: {e:#}"));
     let manager_guard = manager.blocking_lock();

--- a/backend/shared/tests/keiyoushi_live.rs
+++ b/backend/shared/tests/keiyoushi_live.rs
@@ -87,6 +87,7 @@ fn install_mangapill() -> Source {
             bytes,
             "keiyoushi/extensions".to_string(),
             manager,
+            None,
         )
         .unwrap_or_else(|e| panic!("failed to install keiyoushi APK: {e:#}"));
 

--- a/backend/shared/tests/keiyoushi_probe_temp.rs
+++ b/backend/shared/tests/keiyoushi_probe_temp.rs
@@ -45,6 +45,7 @@ fn probe_apk() {
             bytes,
             "keiyoushi/extensions".to_string(),
             &manager,
+            None,
         )
         .unwrap_or_else(|e| panic!("install failed: {e:#}"));
     let manager_guard = manager.blocking_lock();

--- a/frontend/rakuyomi.koplugin/AvailableSourcesListing.lua
+++ b/frontend/rakuyomi.koplugin/AvailableSourcesListing.lua
@@ -13,7 +13,7 @@ local Menu = require("widgets/Menu")
 local _ = require("gettext+")
 local Testing = require("testing")
 local CheckboxDialog = require("CheckboxDialog")
-local formatLanguages = require("utils/formatLanguages")
+local format_languages = require("utils/formatLanguages")
 local hasValue = require("utils/hasValue")
 ---@diagnostic disable-next-line: different-requires
 local util = require("util")
@@ -256,7 +256,7 @@ function AvailableSourcesListing:makeItem(source_information, installed_info)
     callback = function() self:installSource(source_information) end
   end
 
-  local languages_text = formatLanguages(source_information.languages)
+  local languages_text = format_languages(source_information.languages)
   local post_text = source_information.source_of_source
       and string.sub(source_information.source_of_source, 1, 6) .. "..." or
       _("Unknown")
@@ -364,7 +364,7 @@ end
 --- installs the selection.
 --- @private
 --- @param source_information SourceInformation
---- @param outcome { type: 'selection_required', name: string, languages: string[] }
+--- @param outcome InstallOutcomeSelectionRequired
 function AvailableSourcesListing:showLanguageSelection(source_information, outcome)
   local options = {}
   for _, lang in ipairs(outcome.languages) do

--- a/frontend/rakuyomi.koplugin/AvailableSourcesListing.lua
+++ b/frontend/rakuyomi.koplugin/AvailableSourcesListing.lua
@@ -13,6 +13,10 @@ local Menu = require("widgets/Menu")
 local _ = require("gettext+")
 local Testing = require("testing")
 local CheckboxDialog = require("CheckboxDialog")
+local formatLanguages = require("utils/formatLanguages")
+local hasValue = require("utils/hasValue")
+---@diagnostic disable-next-line: different-requires
+local util = require("util")
 
 local DGENERIC_ICON_SIZE = G_defaults:readSetting("DGENERIC_ICON_SIZE")
 local Font = require("ui/font")
@@ -252,13 +256,19 @@ function AvailableSourcesListing:makeItem(source_information, installed_info)
     callback = function() self:installSource(source_information) end
   end
 
+  local languages_text = formatLanguages(source_information.languages)
+  local post_text = source_information.source_of_source
+      and string.sub(source_information.source_of_source, 1, 6) .. "..." or
+      _("Unknown")
+  if languages_text then
+    post_text = languages_text .. " · " .. post_text
+  end
+
   return {
     source_information = source_information,
     text = source_information.name .. " (" .. _("version") .. " " .. tostring(source_information.version) .. ")",
     mandatory = mandatory,
-    post_text = source_information.source_of_source
-        and string.sub(source_information.source_of_source, 1, 6) .. "..." or
-        _("Unknown"),
+    post_text = post_text,
     callback = callback,
   }
 end
@@ -321,10 +331,17 @@ end
 --- @private
 --- @param source_information SourceInformation
 function AvailableSourcesListing:installSource(source_information)
+  self:installSourceWithLanguages(source_information, nil)
+end
+
+--- @private
+--- @param source_information SourceInformation
+--- @param languages string[]|nil
+function AvailableSourcesListing:installSourceWithLanguages(source_information, languages)
   Trapper:wrap(function()
     local response = LoadingDialog:showAndRun(
       _("Installing source..."),
-      function() return Backend.installSource(source_information.id, source_information.source_of_source) end
+      function() return Backend.installSource(source_information.id, source_information.source_of_source, languages) end
     )
 
     if response.type == 'ERROR' then
@@ -333,21 +350,83 @@ function AvailableSourcesListing:installSource(source_information)
       return
     end
 
-    local installed_sources_response = Backend.listInstalledSources()
-    if installed_sources_response.type == 'ERROR' then
-      ErrorDialog:show(installed_sources_response.message)
+    if response.body.type == 'selection_required' then
+      self:showLanguageSelection(source_information, response.body)
 
       return
     end
 
-    self.installed_sources = installed_sources_response.body
-
-    Testing:emitEvent("source_installed", {
-      source = source_information
-    })
-
-    self:updateItems()
+    self:refreshAfterInstall(source_information)
   end)
+end
+
+--- Asks which languages of a multi-source keiyoushi APK to install, then
+--- installs the selection.
+--- @private
+--- @param source_information SourceInformation
+--- @param outcome { type: 'selection_required', name: string, languages: string[] }
+function AvailableSourcesListing:showLanguageSelection(source_information, outcome)
+  local options = {}
+  for _, lang in ipairs(outcome.languages) do
+    table.insert(options, {
+      id = lang,
+      name = lang,
+    })
+  end
+
+  -- Pre-check the language of the tapped entry; fall back to checking
+  -- every language when the entry carries none.
+  local current = {}
+  if source_information.languages then
+    for _, lang in ipairs(source_information.languages) do
+      if hasValue(outcome.languages, lang) then
+        table.insert(current, lang)
+      end
+    end
+  end
+  if #current == 0 then
+    current = util.tableDeepCopy(outcome.languages)
+  end
+
+  local selected = current
+  ---@diagnostic disable-next-line: redundant-parameter
+  local dialog = CheckboxDialog:new {
+    title = _("Select languages to install") .. ": " .. outcome.name,
+    current = current,
+    options = options,
+    update_callback = function(value)
+      selected = value
+    end,
+    dismiss_callback = function()
+      if #selected == 0 then
+        self:showLanguageSelection(source_information, outcome)
+
+        return
+      end
+      self:installSourceWithLanguages(source_information, selected)
+    end,
+  }
+
+  UIManager:show(dialog)
+end
+
+--- @private
+--- @param source_information SourceInformation
+function AvailableSourcesListing:refreshAfterInstall(source_information)
+  local installed_sources_response = Backend.listInstalledSources()
+  if installed_sources_response.type == 'ERROR' then
+    ErrorDialog:show(installed_sources_response.message)
+
+    return
+  end
+
+  self.installed_sources = installed_sources_response.body
+
+  Testing:emitEvent("source_installed", {
+    source = source_information
+  })
+
+  self:updateItems()
 end
 
 --- Fetches and shows the available sources. Must be called from a function wrapped with `Trapper:wrap()`.

--- a/frontend/rakuyomi.koplugin/Backend.lua
+++ b/frontend/rakuyomi.koplugin/Backend.lua
@@ -645,13 +645,23 @@ function Backend.listAvailableSources()
   })
 end
 
---- Installs a source.
---- @return SuccessfulResponse<SourceInformation[]>|ErrorResponse
-function Backend.installSource(source_id, source_of_source)
+--- @class InstallOutcome: { type: 'installed' } | { type: 'selection_required', name: string, languages: string[] }
+---
+--- Installs a source. `languages` (keiyoushi multi-source APKs) restricts
+--- which bundled languages are installed; when omitted, a multi-source APK
+--- answers `selection_required` instead of installing.
+--- @return SuccessfulResponse<InstallOutcome>|ErrorResponse
+function Backend.installSource(source_id, source_of_source, languages)
+  local body = {
+    source_of_source = source_of_source,
+  }
+  if languages ~= nil then
+    body.languages = languages
+  end
   return Backend.requestJson({
     path = "/available-sources/" .. source_id .. "/install",
     method = "POST",
-    body = source_of_source,
+    body = body,
   })
 end
 

--- a/frontend/rakuyomi.koplugin/Backend.lua
+++ b/frontend/rakuyomi.koplugin/Backend.lua
@@ -645,11 +645,16 @@ function Backend.listAvailableSources()
   })
 end
 
---- @class InstallOutcome: { type: 'installed' } | { type: 'selection_required', name: string, languages: string[] }
----
+--- @class InstallOutcomeInstalled: { type: 'installed' }
+--- @class InstallOutcomeSelectionRequired: { type: 'selection_required', name: string, languages: string[] }
+--- @alias InstallOutcome InstallOutcomeInstalled|InstallOutcomeSelectionRequired
+
 --- Installs a source. `languages` (keiyoushi multi-source APKs) restricts
 --- which bundled languages are installed; when omitted, a multi-source APK
 --- answers `selection_required` instead of installing.
+--- @param source_id string
+--- @param source_of_source string
+--- @param languages string[]|nil
 --- @return SuccessfulResponse<InstallOutcome>|ErrorResponse
 function Backend.installSource(source_id, source_of_source, languages)
   local body = {

--- a/frontend/rakuyomi.koplugin/InstalledSourcesListing.lua
+++ b/frontend/rakuyomi.koplugin/InstalledSourcesListing.lua
@@ -10,7 +10,7 @@ local Menu = require("widgets/Menu")
 local ErrorDialog = require("ErrorDialog")
 local SourceSettings = require("SourceSettings")
 local Testing = require("testing")
-local formatLanguages = require("utils/formatLanguages")
+local format_languages = require("utils/formatLanguages")
 
 --- @class InstalledSourcesListing: { [any]: any }
 --- @field installed_sources SourceInformation[]
@@ -79,7 +79,7 @@ end
 function InstalledSourcesListing:generateItemTableFromInstalledSources(installed_sources)
   local item_table = {}
   for __,source_information in ipairs(installed_sources) do
-    local languages_text = formatLanguages(source_information.languages)
+    local languages_text = format_languages(source_information.languages)
     local post_text = source_information.source_of_source and string.sub(source_information.source_of_source, 0, 6) .. "..." or
         _("Unknown")
     if languages_text then

--- a/frontend/rakuyomi.koplugin/InstalledSourcesListing.lua
+++ b/frontend/rakuyomi.koplugin/InstalledSourcesListing.lua
@@ -10,6 +10,7 @@ local Menu = require("widgets/Menu")
 local ErrorDialog = require("ErrorDialog")
 local SourceSettings = require("SourceSettings")
 local Testing = require("testing")
+local formatLanguages = require("utils/formatLanguages")
 
 --- @class InstalledSourcesListing: { [any]: any }
 --- @field installed_sources SourceInformation[]
@@ -60,10 +61,12 @@ function InstalledSourcesListing:updateItems()
     self.item_table = self:generateItemTableFromInstalledSources(self.installed_sources)
     self.multilines_show_more_text = false
     self.items_per_page = nil
+    self.single_line = true
   else
     self.item_table = self:generateEmptyViewItemTable()
     self.multilines_show_more_text = true
     self.items_per_page = 1
+    self.single_line = false
   end
 
   Menu.updateItems(self)
@@ -76,11 +79,17 @@ end
 function InstalledSourcesListing:generateItemTableFromInstalledSources(installed_sources)
   local item_table = {}
   for __,source_information in ipairs(installed_sources) do
+    local languages_text = formatLanguages(source_information.languages)
+    local post_text = source_information.source_of_source and string.sub(source_information.source_of_source, 0, 6) .. "..." or
+        _("Unknown")
+    if languages_text then
+      post_text = languages_text .. " · " .. post_text
+    end
+
     table.insert(item_table, {
       source_information = source_information,
       text = source_information.name .. " (" .. _("version") .. " " .. tostring(source_information.version) .. ")",
-      post_text = source_information.source_of_source and string.sub(source_information.source_of_source, 0, 6) .. "..." or
-          _("Unknown"),
+      post_text = post_text,
     })
   end
 

--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -371,10 +371,12 @@ function LibraryView:updateItems()
     self.item_table = self:generateItemTableFromMangas(self.mangas)
     self.multilines_show_more_text = false
     self.items_per_page = nil
+    self.single_line = true
   else
     self.item_table = self:generateEmptyViewItemTable()
     self.multilines_show_more_text = true
     self.items_per_page = 1
+    self.single_line = false
   end
 
   local mode = self:getLibraryViewMode()
@@ -1206,11 +1208,25 @@ function LibraryView:openSettingsSearchDialog()
   end
 
   local key = "exlucde_source_ids_select_search"
+  local options = {}
+  local formatLanguages = require("utils/formatLanguages")
+  for _, source_information in ipairs(response.body) do
+    local name = source_information.name
+    local languages_text = formatLanguages(source_information.languages)
+    if languages_text then
+      name = name .. " (" .. languages_text .. ")"
+    end
+    table.insert(options, {
+      id = source_information.id,
+      name = name,
+    })
+  end
+
   ---@diagnostic disable-next-line: redundant-parameter
   local dialog = CheckboxDialog:new {
     title = _("Exclude source search for") .. " \"" .. _("Search") .. "*\"",
     current = G_reader_settings:readSetting(key, {}),
-    options = response.body,
+    options = options,
     update_callback = function(value)
       G_reader_settings:saveSetting(key, value)
     end

--- a/frontend/rakuyomi.koplugin/LibraryView.lua
+++ b/frontend/rakuyomi.koplugin/LibraryView.lua
@@ -1209,10 +1209,10 @@ function LibraryView:openSettingsSearchDialog()
 
   local key = "exlucde_source_ids_select_search"
   local options = {}
-  local formatLanguages = require("utils/formatLanguages")
+  local format_languages = require("utils/formatLanguages")
   for _, source_information in ipairs(response.body) do
     local name = source_information.name
-    local languages_text = formatLanguages(source_information.languages)
+    local languages_text = format_languages(source_information.languages)
     if languages_text then
       name = name .. " (" .. languages_text .. ")"
     end

--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -19,7 +19,7 @@ local Icons = require("Icons")
 local MangaInfoWidget = require("MangaInfoWidget")
 local calcLastReadText = require("utils/calcLastReadText")
 local Trapper = require("ui/trapper")
-local formatLanguages = require("utils/formatLanguages")
+local format_languages = require("utils/formatLanguages")
 
 --- @class MangaSearchResults: { [any]: any }
 --- @field results Manga[]
@@ -146,7 +146,7 @@ function MangaSearchResults:generateItemTableFromSearchResults(results)
     local mandatory = table.concat(mandatory_parts)
 
     local source_text = manga.source.name
-    local languages_text = formatLanguages(manga.source.languages)
+    local languages_text = format_languages(manga.source.languages)
     if languages_text then
       source_text = source_text .. " (" .. languages_text .. ")"
     end

--- a/frontend/rakuyomi.koplugin/MangaSearchResults.lua
+++ b/frontend/rakuyomi.koplugin/MangaSearchResults.lua
@@ -19,6 +19,7 @@ local Icons = require("Icons")
 local MangaInfoWidget = require("MangaInfoWidget")
 local calcLastReadText = require("utils/calcLastReadText")
 local Trapper = require("ui/trapper")
+local formatLanguages = require("utils/formatLanguages")
 
 --- @class MangaSearchResults: { [any]: any }
 --- @field results Manga[]
@@ -144,10 +145,16 @@ function MangaSearchResults:generateItemTableFromSearchResults(results)
 
     local mandatory = table.concat(mandatory_parts)
 
+    local source_text = manga.source.name
+    local languages_text = formatLanguages(manga.source.languages)
+    if languages_text then
+      source_text = source_text .. " (" .. languages_text .. ")"
+    end
+
     table.insert(item_table, {
       manga = manga,
       text = manga.title,
-      post_text = is_cover and mandatory or manga.source.name,
+      post_text = is_cover and mandatory or source_text,
       manga_cover = self.search_view_mode ~= "base" and manga.manga_cover or nil,
       mandatory = not is_cover and mandatory or nil,
     })

--- a/frontend/rakuyomi.koplugin/testing.lua
+++ b/frontend/rakuyomi.koplugin/testing.lua
@@ -135,10 +135,19 @@ function Testing:periodicallyReadIPC()
           install_source = function()
             local Backend = require("Backend")
             local source_id = decoded.params.source_id
+            local languages = decoded.params.languages
 
-            local response = Backend.installSource(source_id, "")
+            local response = Backend.installSource(source_id, "", languages)
             if response.type == 'ERROR' then
               logger.warn("Failed to install source:", response.message)
+
+              return
+            end
+
+            if response.body.type == "selection_required" then
+              logger.warn(
+                "Source installation requires a language selection; pass `languages` via IPC params",
+                response.body.name)
 
               return
             end

--- a/frontend/rakuyomi.koplugin/testing.lua
+++ b/frontend/rakuyomi.koplugin/testing.lua
@@ -136,7 +136,7 @@ function Testing:periodicallyReadIPC()
             local Backend = require("Backend")
             local source_id = decoded.params.source_id
 
-            local response = Backend.installSource(source_id)
+            local response = Backend.installSource(source_id, "")
             if response.type == 'ERROR' then
               logger.warn("Failed to install source:", response.message)
 

--- a/frontend/rakuyomi.koplugin/utils/formatLanguages.lua
+++ b/frontend/rakuyomi.koplugin/utils/formatLanguages.lua
@@ -1,0 +1,11 @@
+--- Formats a list of language codes for display, e.g. `["en", "vi"]` becomes
+--- `"en, vi"`. Returns `nil` for an empty list so callers can skip the
+--- language suffix entirely.
+--- @param languages string[]|nil
+--- @return string|nil
+return function(languages)
+  if not languages or #languages == 0 then
+    return nil
+  end
+  return table.concat(languages, ", ")
+end


### PR DESCRIPTION
…
- fall back to the manifest `lang` when reporting installed source languages (keiyoushi/mangayomi manifests only set `lang`)
- show each source's languages in the installed/available source lists, search results and the exclude-from-search dialog
- ask which languages to install when a keiyoushi APK bundles several sources; the selection is stored in the extension meta file and kept across restarts
- name keiyoushi entries of multi-language packages `<pkg>:<lang>` so available entries match the sources an install produces
- bump dexvm to 0.1.15 (declare instance fields on shim classes, fixing "no field element in kotlin.jvm.internal.Ref$ObjectRef" resolution errors when searching through keiyoushi sources)

closes #312 