### PR TITLE
fix(html): return element children only

### DIFF
--- a/backend/shared/src/source/html_element.rs
+++ b/backend/shared/src/source/html_element.rs
@@ -127,7 +127,7 @@ impl HTMLElement {
     pub fn children(&self, store: &mut WasmStore) -> Option<Vec<Self>> {
         let node = self.node_ref(store)?;
 
-        node.children()
+        node.element_children()
             .into_iter()
             .map(|node| self.to_element(node.id))
             .collect::<Vec<_>>()
@@ -589,6 +589,29 @@ mod tests {
             .collect();
         assert!(text_kinds.contains(&2));
         assert!(text_kinds.contains(&5));
+    }
+
+    #[test]
+    fn children_returns_elements_while_child_nodes_returns_all_nodes() {
+        let (mut store, element) = setup_html_store(
+            "<div>leading<!-- comment --><span>one</span>middle<a>two</a>trailing</div>",
+        );
+        let div = element.select_soup(&mut store, "div").unwrap().unwrap();
+
+        let children = div[0].children(&mut store).unwrap();
+        assert_eq!(children.len(), 2);
+        assert!(children
+            .iter()
+            .all(|child| child.kind(&mut store).unwrap() == 5));
+
+        let child_nodes = div[0].child_nodes(&mut store).unwrap();
+        let kinds: Vec<i32> = child_nodes
+            .iter()
+            .map(|node| node.kind(&mut store).unwrap())
+            .collect();
+        assert!(kinds.contains(&2));
+        assert!(kinds.contains(&4));
+        assert_eq!(kinds.iter().filter(|&&kind| kind == 5).count(), 2);
     }
 
     #[test]

--- a/backend/shared/src/source/html_element.rs
+++ b/backend/shared/src/source/html_element.rs
@@ -124,6 +124,10 @@ impl HTMLElement {
             .collect::<Vec<_>>()
             .into()
     }
+    /// Returns direct element children.
+    ///
+    /// Text and comment nodes are excluded. Use `child_nodes` to retrieve all
+    /// direct child nodes.
     pub fn children(&self, store: &mut WasmStore) -> Option<Vec<Self>> {
         let node = self.node_ref(store)?;
 

--- a/backend/shared/tests/aidoku_novelbuddy_issue328.rs
+++ b/backend/shared/tests/aidoku_novelbuddy_issue328.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 const INDEX_URL: &str = "https://aidoku-community.github.io/sources/index.min.json";
 const SOURCE_ID: &str = "en.novelbuddy";
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[ignore = "live network test; run with --ignored"]
 async fn novelbuddy_chapter_contains_text_issue328() {
     let client = tls::client_builder().build().unwrap();

--- a/backend/shared/tests/aidoku_novelbuddy_issue328.rs
+++ b/backend/shared/tests/aidoku_novelbuddy_issue328.rs
@@ -1,0 +1,136 @@
+//! Live regression test for issue #328 (NovelBuddy chapter content).
+//!
+//! Network-dependent: gated behind `#[ignore]` so CI stays offline; run with:
+//!
+//! ```sh
+//! cargo test -p shared --test aidoku_novelbuddy_issue328 -- --ignored --nocapture
+//! ```
+
+use std::sync::Arc;
+
+use shared::{
+    model::SourceId, settings::Settings, source::SourceBackend, source_manager::SourceManager, tls,
+};
+use tokio_util::sync::CancellationToken;
+
+const INDEX_URL: &str = "https://aidoku-community.github.io/sources/index.min.json";
+const SOURCE_ID: &str = "en.novelbuddy";
+
+#[tokio::test]
+#[ignore = "live network test; run with --ignored"]
+async fn novelbuddy_chapter_contains_text_issue328() {
+    let client = tls::client_builder().build().unwrap();
+    let index: serde_json::Value = client
+        .get(INDEX_URL)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let entry = index["sources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|source| source["id"].as_str() == Some(SOURCE_ID))
+        .unwrap();
+    let download_url = format!(
+        "https://aidoku-community.github.io/sources/{}",
+        entry["downloadURL"].as_str().unwrap()
+    );
+    let bytes = client
+        .get(download_url)
+        .send()
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+
+    let dir = std::env::temp_dir().join("rakuyomi-issue328-novelbuddy");
+    std::fs::create_dir_all(&dir).unwrap();
+    let file = dir.join(format!("{SOURCE_ID}.aix"));
+    std::fs::write(&file, &bytes).unwrap();
+
+    let mut manager = SourceManager::from_folder(dir, Settings::default()).unwrap();
+    let arc_manager = Arc::new(tokio::sync::Mutex::new(manager.clone()));
+    manager
+        .install_source(
+            &SourceId::new(SOURCE_ID.to_string()),
+            bytes.to_vec(),
+            "issue328-test".into(),
+            &arc_manager,
+        )
+        .unwrap();
+    let source = manager
+        .sources_by_id
+        .get(&SourceId::new(SOURCE_ID.to_string()))
+        .unwrap()
+        .clone();
+
+    let mangas = tokio::task::spawn_blocking({
+        let source = source.clone();
+        move || {
+            let mut backend = match &source.backend {
+                SourceBackend::Aidoku(source) => source.lock().unwrap(),
+                _ => panic!("not an aidoku source"),
+            };
+            backend
+                .get_manga_list(
+                    CancellationToken::new(),
+                    aidoku::Listing {
+                        id: "latest".into(),
+                        name: "Latest Updates".into(),
+                        kind: aidoku::ListingKind::default(),
+                    },
+                )
+                .unwrap()
+        }
+    })
+    .await
+    .unwrap();
+    assert!(!mangas.is_empty(), "NovelBuddy returned no novels");
+
+    let chapters = tokio::task::spawn_blocking({
+        let source = source.clone();
+        let manga_id = mangas[0].id.clone();
+        move || {
+            let mut backend = match &source.backend {
+                SourceBackend::Aidoku(source) => source.lock().unwrap(),
+                _ => panic!("not an aidoku source"),
+            };
+            backend
+                .get_chapter_list(CancellationToken::new(), manga_id)
+                .unwrap()
+        }
+    })
+    .await
+    .unwrap();
+    assert!(!chapters.is_empty(), "NovelBuddy returned no chapters");
+
+    let chapter = chapters[0].clone();
+    let pages = tokio::task::spawn_blocking(move || {
+        let mut backend = match &source.backend {
+            SourceBackend::Aidoku(source) => source.lock().unwrap(),
+            _ => panic!("not an aidoku source"),
+        };
+        backend
+            .get_page_list(
+                CancellationToken::new(),
+                chapter.manga_id,
+                chapter.id.clone(),
+                chapter.chapter_num,
+            )
+            .unwrap()
+    })
+    .await
+    .unwrap();
+    assert!(!pages.is_empty(), "NovelBuddy returned no chapter pages");
+    assert!(
+        pages.iter().any(|page| page
+            .text
+            .as_ref()
+            .is_some_and(|text| !text.trim().is_empty())),
+        "NovelBuddy chapter pages contained no text"
+    );
+}


### PR DESCRIPTION
## Summary

`HTMLElement::children()` now returns element nodes only, as required by the Aidoku Next SDK contract. `child_nodes()` keeps returning text, comment, and element nodes.

## Related

Related: #328

## Tests

- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo test` (288 passed, 7 ignored), run twice consecutively
- Focused regression test covers text, comment, and element children.
