### PR TITLE
fix(suwayomi): correct GraphQL queries against real Suwayomi schema

### DIFF
--- a/backend/shared/src/tracking/suwayomi.rs
+++ b/backend/shared/src/tracking/suwayomi.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
@@ -31,7 +31,12 @@ impl Tracker for SuwayomiTracker {
 
         #[derive(Deserialize)]
         struct SearchData {
-            search: Vec<SeriesNode>,
+            mangas: MangaNodeList,
+        }
+
+        #[derive(Deserialize)]
+        struct MangaNodeList {
+            nodes: Vec<SeriesNode>,
         }
 
         #[derive(Deserialize)]
@@ -57,11 +62,17 @@ impl Tracker for SuwayomiTracker {
 
         let graphql_query = r#"
             query SearchSeries($query: String!) {
-                search(query: $query, type: MANGA) {
-                    id
-                    title
-                    chapters {
-                        totalCount
+                mangas(
+                    condition: { inLibrary: true }
+                    filter: { title: { includesInsensitive: $query } }
+                    first: 50
+                ) {
+                    nodes {
+                        id
+                        title
+                        chapters {
+                            totalCount
+                        }
                     }
                 }
             }
@@ -88,7 +99,8 @@ impl Tracker for SuwayomiTracker {
 
         Ok(response
             .data
-            .search
+            .mangas
+            .nodes
             .into_iter()
             .map(|series| TrackingCandidate {
                 service: TrackingService::Suwayomi,
@@ -145,7 +157,7 @@ impl Tracker for SuwayomiTracker {
         let client = build_client();
 
         let graphql_query = r#"
-            query MangaProgress($id: Long!) {
+            query MangaProgress($id: Int!) {
                 manga(id: $id) {
                     unreadCount
                     chapters {
@@ -248,6 +260,47 @@ impl Tracker for SuwayomiTracker {
 
         self.fetch_progress(settings, media_id).await
     }
+
+    async fn get_user(&self, settings: &Settings) -> Result<Option<String>> {
+        #[derive(Deserialize)]
+        struct ProbeResponse {
+            data: Option<serde_json::Value>,
+            #[serde(default)]
+            errors: Option<serde_json::Value>,
+        }
+
+        let base_url = require_url(settings)?;
+        let api_key = require_api_key(settings)?;
+        let client = build_client();
+
+        let mut request = client.post(format!("{base_url}/graphql"));
+        if let Some((user, pass)) = api_key.split_once(':') {
+            request = request.basic_auth(user, Some(pass));
+        } else {
+            request = request.basic_auth(api_key, None::<&str>);
+        }
+        let request = request.json(&GraphqlRequest {
+            query: "query Probe { mangas(first: 1) { totalCount } }".to_string(),
+            variables: None,
+        });
+
+        let response: ProbeResponse = request
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<ProbeResponse>()
+            .await
+            .context("failed to decode Suwayomi probe response")?;
+
+        if let Some(errors) = response.errors {
+            bail!("Suwayomi returned GraphQL errors: {errors}");
+        }
+        if response.data.is_none() {
+            bail!("Suwayomi returned no data");
+        }
+
+        Ok(Some("suwayomi".to_string()))
+    }
 }
 
 impl SuwayomiTracker {
@@ -290,7 +343,7 @@ impl SuwayomiTracker {
         }
 
         let graphql_query = r#"
-            query MangaChapters($id: Long!) {
+            query MangaChapters($id: Int!) {
                 manga(id: $id) {
                     chapters {
                         nodes { id }


### PR DESCRIPTION
**Suggested title:** `fix(suwayomi): correct GraphQL queries against the real Suwayomi schema`

---

Fixes #332.

The Suwayomi tracker cannot connect to any Suwayomi server. The symptom is reported as an auth failure, but authentication isn't involved — the tracker fails identically with Basic Auth and with auth mode `NONE`. There are three independent defects, all in `backend/shared/src/tracking/suwayomi.rs`.

### 1. `Validate` could never succeed

`SuwayomiTracker` didn't implement `get_user`, so it fell through to the trait default (`Ok(None)`) at `tracking/mod.rs:50`. `validate_credentials` then calls `.context("invalid credentials")` on that `Option`, which turns `None` into an error whose message is the literal string users were seeing. No HTTP request was ever made, which is why the message was identical regardless of auth mode.

This PR adds a real `get_user` that probes the server. Note it inspects the GraphQL `errors` array explicitly rather than relying on `error_for_status()` — Suwayomi returns HTTP 200 on schema errors, so status alone would report success against a mismatched server.

### 2. The search query used a field that doesn't exist

The query called `Query.search(query:, type: MANGA)`. Suwayomi has no such field; a real server (2.3.2333) replies:

```
Validation error (FieldUndefined@[search]) : Field 'search' in type 'Query' is undefined
```

Per `MangaQuery.kt`, list queries are `mangas(condition:, filter:, first:, ...)` returning a `MangaNodeList`, and title search goes through `MangaFilter.title`, a `StringFilter` exposing `includesInsensitive`. The query and the `SearchData` response envelope are updated accordingly.

### 3. Manga IDs are `Int`, not `Long`

`fetch_progress` and `fetch_all_chapter_ids` declared `$id: Long!`; `MangaQuery.kt:57` is `fun manga(id: Int, ...)`. The `updateChapters` mutation in `push_progress` was already correct and is untouched.

### Verification

Each fix was checked against a live Suwayomi 2.3.2333 instance before being written. The corrected search query:

```bash
curl -s https://<host>/api/graphql -H 'Content-Type: application/json' \
  -d '{"query":"query($q:String!){mangas(condition:{inLibrary:true},filter:{title:{includesInsensitive:$q}},first:50){nodes{id title chapters{totalCount}}}}","variables":{"q":"dandadan"}}'

{"data":{"mangas":{"nodes":[{"id":112,"title":"Dandadan","chapters":{"totalCount":247}}]}}}
```

### One decision worth reviewing

I scoped search with `condition: { inLibrary: true }` and `first: 50`. Unscoped, `mangas()` returns every row in the manga table — including metadata for series merely fetched from a source — which on my server is ~6,700 entries for a one-character query. That's unusable as a picker and a lot to deserialize on an e-reader. Scoped, the same query returns one result.

The tradeoff is you can't track a series that isn't in your library yet. Happy to drop the `condition` if you'd rather keep search unscoped, or move it behind a setting — it's a product call, not a correctness one.

### Not included

`kavita.rs` and `komga.rs` are also missing `get_user`, so their `Validate` buttons fail the same way for the same reason. I've left them alone since I can't test either service, but the fix is the same shape if you want it in a follow-up.

The URL placeholder in `TrackingSettings.lua` is also misleading: it shows `http://localhost:4567`, but the tracker builds `{base_url}/graphql` while Suwayomi's endpoint is `/api/graphql`, so users must enter `.../api` for anything to work. Not changed here to keep this PR to the backend, but worth either appending `/api/graphql` in code or updating the placeholder.

Separately, `require_api_key` rejects an empty value before any request is made, so users running auth mode `NONE` still have to invent a dummy key. Left as-is for the same reason.

### Testing

CI passes. I haven't been able to run the compiled ARM build on-device yet, so on-device confirmation of the full tracker flow is still outstanding — happy to report back once I've tested on my Colorsoft.