### PR TITLE
fix(ui): reconnect to Wi-Fi before retrying source list fetch (#334)

### DIFF
--- a/frontend/rakuyomi.koplugin/AvailableSourcesListing.lua
+++ b/frontend/rakuyomi.koplugin/AvailableSourcesListing.lua
@@ -646,78 +646,85 @@ end
 --- already online.
 --- @param onReturnCallback any
 --- @param retried boolean? whether this call is a retry after a WiFi reconnect
+--- @return nil
 function AvailableSourcesListing:fetchAndShow(onReturnCallback, retried)
-  local installed_sources_response = Backend.listInstalledSources()
-  if installed_sources_response.type == 'ERROR' then
-    ErrorDialog:show(installed_sources_response.message)
-
-    return
-  end
-
-  local installed_sources = installed_sources_response.body
-
-  local available_sources_response = LoadingDialog:showAndRun("Fetching available sources...", function()
-    return Backend.listAvailableSources()
-  end)
-
-  if available_sources_response.type == 'ERROR' then
-    if not NetworkMgr:isConnected() then
-      if retried then
-        -- The reconnect retry also failed while offline: stop here.
-        ErrorDialog:show(available_sources_response.message)
-
-        return
-      end
-
-      -- The fetch failed because we're offline. Try to get back online
-      -- (honoring the "action when Wi-Fi is off" setting), then retry once.
-      local connection_pending = NetworkMgr.pending_connection
-      local wifi_enable = NetworkMgr:beforeWifiAction(function()
-        self:fetchAndShow(onReturnCallback, true)
-      end)
-
-      if wifi_enable == false then
-        ErrorDialog:show(available_sources_response.message)
-      elseif wifi_enable == nil and connection_pending then
-        -- beforeWifiAction dropped our retry callback (EBUSY) because a
-        -- previous connection attempt is still ongoing. Queue the retry for
-        -- when it finishes instead of silently giving up.
-        NetworkMgr:scheduleConnectivityCheck(function()
-          self:fetchAndShow(onReturnCallback, true)
-        end)
-      end
+  -- Establish our own Trapper context (mirroring `ChapterListing:downloadChapter`)
+  -- so the retry callback from `NetworkMgr:beforeWifiAction` /
+  -- `scheduleConnectivityCheck` can re-enter this function asynchronously:
+  -- `LoadingDialog:showAndRun` requires a `Trapper:wrap()` context.
+  Trapper:wrap(function()
+    local installed_sources_response = Backend.listInstalledSources()
+    if installed_sources_response.type == 'ERROR' then
+      ErrorDialog:show(installed_sources_response.message)
 
       return
     end
 
-    ErrorDialog:show(available_sources_response.message)
+    local installed_sources = installed_sources_response.body
 
-    return
-  end
+    local available_sources_response = LoadingDialog:showAndRun("Fetching available sources...", function()
+      return Backend.listAvailableSources()
+    end)
 
-  local available_sources = available_sources_response.body
+    if available_sources_response.type == 'ERROR' then
+      if not NetworkMgr:isConnected() then
+        if retried then
+          -- The reconnect retry also failed while offline: stop here.
+          ErrorDialog:show(available_sources_response.message)
 
-  local settings_response = Backend.getSettings()
-  if settings_response.type == 'ERROR' then
-    ErrorDialog:show(settings_response.message)
+          return
+        end
 
-    return
-  end
-  local settings = settings_response.body
+        -- The fetch failed because we're offline. Try to get back online
+        -- (honoring the "action when Wi-Fi is off" setting), then retry once.
+        local connection_pending = NetworkMgr.pending_connection
+        local wifi_enable = NetworkMgr:beforeWifiAction(function()
+          self:fetchAndShow(onReturnCallback, true)
+        end)
 
-  local ui = AvailableSourcesListing:new {
-    installed_sources = installed_sources,
-    available_sources = available_sources,
-    settings = settings,
-    langs_selected = G_reader_settings:readSetting("rakuyomi_langs_selected", {}),
-    repos_selected = G_reader_settings:readSetting("rakuyomi_repos_selected", {}),
-    on_return_callback = onReturnCallback,
-    covers_fullscreen = true, -- hint for UIManager:_repaint()
-  }
-  ui.on_return_callback = onReturnCallback
-  UIManager:show(ui)
+        if wifi_enable == false then
+          ErrorDialog:show(available_sources_response.message)
+        elseif wifi_enable == nil and connection_pending then
+          -- beforeWifiAction dropped our retry callback (EBUSY) because a
+          -- previous connection attempt is still ongoing. Queue the retry for
+          -- when it finishes instead of silently giving up.
+          NetworkMgr:scheduleConnectivityCheck(function()
+            self:fetchAndShow(onReturnCallback, true)
+          end)
+        end
 
-  Testing:emitEvent("available_sources_listing_shown")
+        return
+      end
+
+      ErrorDialog:show(available_sources_response.message)
+
+      return
+    end
+
+    local available_sources = available_sources_response.body
+
+    local settings_response = Backend.getSettings()
+    if settings_response.type == 'ERROR' then
+      ErrorDialog:show(settings_response.message)
+
+      return
+    end
+    local settings = settings_response.body
+
+    local ui = AvailableSourcesListing:new {
+      installed_sources = installed_sources,
+      available_sources = available_sources,
+      settings = settings,
+      langs_selected = G_reader_settings:readSetting("rakuyomi_langs_selected", {}),
+      repos_selected = G_reader_settings:readSetting("rakuyomi_repos_selected", {}),
+      on_return_callback = onReturnCallback,
+      covers_fullscreen = true, -- hint for UIManager:_repaint()
+    }
+    ui.on_return_callback = onReturnCallback
+    UIManager:show(ui)
+
+    Testing:emitEvent("available_sources_listing_shown")
+  end)
 end
 
 return AvailableSourcesListing

--- a/frontend/rakuyomi.koplugin/AvailableSourcesListing.lua
+++ b/frontend/rakuyomi.koplugin/AvailableSourcesListing.lua
@@ -11,6 +11,7 @@ local Backend = require("Backend")
 local ErrorDialog = require("ErrorDialog")
 local LoadingDialog = require("LoadingDialog")
 local Menu = require("widgets/Menu")
+local NetworkMgr = require("ui/network/manager")
 local _ = require("gettext+")
 local Testing = require("testing")
 local CheckboxDialog = require("CheckboxDialog")
@@ -636,8 +637,16 @@ function AvailableSourcesListing:refreshAfterInstall(source_information)
 end
 
 --- Fetches and shows the available sources. Must be called from a function wrapped with `Trapper:wrap()`.
+---
+--- When the fetch fails while the device is offline, the WiFi-reconnect
+--- dance from `ChapterListing:downloadChapter` (issue #277) is replayed:
+--- `NetworkMgr:beforeWifiAction` (which honors the "action when Wi-Fi is
+--- off" setting) brings the device back online and the fetch is retried
+--- once; the error is only shown when reconnecting fails or the device is
+--- already online.
 --- @param onReturnCallback any
-function AvailableSourcesListing:fetchAndShow(onReturnCallback)
+--- @param retried boolean? whether this call is a retry after a WiFi reconnect
+function AvailableSourcesListing:fetchAndShow(onReturnCallback, retried)
   local installed_sources_response = Backend.listInstalledSources()
   if installed_sources_response.type == 'ERROR' then
     ErrorDialog:show(installed_sources_response.message)
@@ -652,6 +661,35 @@ function AvailableSourcesListing:fetchAndShow(onReturnCallback)
   end)
 
   if available_sources_response.type == 'ERROR' then
+    if not NetworkMgr:isConnected() then
+      if retried then
+        -- The reconnect retry also failed while offline: stop here.
+        ErrorDialog:show(available_sources_response.message)
+
+        return
+      end
+
+      -- The fetch failed because we're offline. Try to get back online
+      -- (honoring the "action when Wi-Fi is off" setting), then retry once.
+      local connection_pending = NetworkMgr.pending_connection
+      local wifi_enable = NetworkMgr:beforeWifiAction(function()
+        self:fetchAndShow(onReturnCallback, true)
+      end)
+
+      if wifi_enable == false then
+        ErrorDialog:show(available_sources_response.message)
+      elseif wifi_enable == nil and connection_pending then
+        -- beforeWifiAction dropped our retry callback (EBUSY) because a
+        -- previous connection attempt is still ongoing. Queue the retry for
+        -- when it finishes instead of silently giving up.
+        NetworkMgr:scheduleConnectivityCheck(function()
+          self:fetchAndShow(onReturnCallback, true)
+        end)
+      end
+
+      return
+    end
+
     ErrorDialog:show(available_sources_response.message)
 
     return


### PR DESCRIPTION
## What

When fetching available sources while the device is offline, RakuYomi used
to fail immediately with a DNS error (e.g. "failed to lookup address
information") without ever trying to get back online. This mirrors the fix
from #277 / 97afb7c, which was applied to chapter downloads but not to
source list fetching.

## Change

`AvailableSourcesListing:fetchAndShow` now replays the exact
`NetworkMgr:beforeWifiAction` dance from `ChapterListing:downloadChapter`:

- if the `/available-sources` fetch returns an ERROR while
  `NetworkMgr:isConnected()` is false, the fetch is retried once after
  `beforeWifiAction` (which honors the KOReader *Action when Wi-Fi is off*
  setting) brings the device back online;
- the retry carries an explicit `retried` flag so a failed reconnect retry
  shows the error dialog instead of reconnecting again (unbounded retries
  prevented, as in #277's follow-up);
- when `beforeWifiAction` drops the retry callback (EBUSY) because a
  connection attempt is already ongoing, the retry is queued via
  `NetworkMgr:scheduleConnectivityCheck` instead of being silently dropped.

The fetch is triggered from both "Manage sources -> Available sources" and
the refresh path, so both the "add" and "refresh" flows from the issue are
covered (adding a source list itself is a local settings-only operation).

## Tests

- `luacheck frontend/rakuyomi.koplugin/AvailableSourcesListing.lua` — clean
- Lua-only change; Rust workspace untouched

Fixes #334